### PR TITLE
Rewrite FD4Singleton finder

### DIFF
--- a/resources/include/tga/code_utils.h
+++ b/resources/include/tga/code_utils.h
@@ -97,10 +97,6 @@ bool code_reloc(fn_info* original, fn_info* relocated, void* dest, size_t dest_s
         hde64_disasm((void*)ip, &instr);
         if (instr.flags & F_ERROR) { original->function_begin = 0; goto ret; }
 
-        if (ip == 0x7FF7E7116896) {
-            int _bp = 0;
-        }
-
         if (ip < original->code_begin) original->code_begin = ip;
         if (ip > original->code_end) original->code_end = ip + instr.len;
 

--- a/resources/include/tga/fd4_singleton.h
+++ b/resources/include/tga/fd4_singleton.h
@@ -3,46 +3,94 @@
 
 #include "mem_region.h"
 #include "pattern.h"
-#include "bsearch.h"
+#include "string.h"
 
-// Find all unique singleton addresses by searching for null singleton checks in a memory region.
-int find_singleton_addresses(const region* reg, intptr_t* out_array, int out_array_size) {
-    /* matches the following instruction pattern with registers and addresses masked out
-       140aa2a39 48 8b 0d        MOV        RCX,qword ptr [DAT_143c65b38]                    = ??
-                 f8 30 1c 03
-       140aa2a40 48 85 c9        TEST       RCX,RCX
-       140aa2a43 75 2e           JNZ        LAB_140aa2a73
-       140aa2a45 48 8d 0d        LEA        RCX,[DAT_143c42a19]                              = ??
-                 cd ff 19 03
-       140aa2a4c e8 0f a5        CALL       FUN_141e2cf60                                    undefined FUN_141e2cf60()
-                 38 01
-    */
-    static const uint8_t aob[] =  { 0x48, 0x8b, 0x0d, 0xf8, 0x30, 0x1c, 0x03, 0x48, 0x85, 0xc9, 0x75, 0x2e, 0x48, 0x8d, 0x0d, 0xcd, 0xff, 0x19, 0x03, 0xe8, 0x0f, 0xa5, 0x38, 0x01 };
-    static const uint8_t mask[] = { 0xFF, 0xFF, 0xC7, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xC0, 0xFF, 0x00, 0xFF, 0xFF, 0xC7, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00, 0x00 };
+typedef struct _fd4_singleton_basic_info {
+    intptr_t address;
+    const char* full_name;
+    const char* simple_name;
+} fd4_singleton_basic_info;
 
-    if (out_array_size == 0)
-        return 0;
+extern size_t strnlen(const char* str, size_t max_len);
+size_t find_fd4_singletons(fd4_singleton_basic_info* out_array, size_t out_array_size) {
+    region text, data, rdata;
+    region_from_module(&text, NULL, ".text");
+    region_from_module(&data, NULL, ".data");
+    region_from_module(&rdata, NULL, ".rdata");
+
+    pattern null_check;
+    bool s = pattern_init(&null_check,
+        "48 8b ? ? ? ? ? "  //  0 MOV REG, [MEM]
+        "48 85 ? "          //  7 TEST REG, REG
+        "75 2e "            // 10 JNZ +2e
+        "48 8d 0d ? ? ? ? " // 12 LEA RCX, [runtime_class_metadata]
+        "e8 ? ? ? ? "       // 19 CALL get_singleton_name
+        "4c 8b c8 "         // 24 MOV R9, RAX
+        "4c 8d 05 ? ? ? ? " // 27 LEA R8, [%s:未初期化のシングルトンにアクセスしました]
+        "ba ? ? 00 00 "     // 34 MOV EDX, 0x0000????
+        "48 8d 0d ? ? ? ? " // 39 LEA RCX, [file_path]
+        "e8 ? ? ? ?"        // 46 CALL log_thunk
+    );
+    if (!s) return 0;
+
+    const size_t null_checks_size = 0x4000; // There should be a few thousand, this is overkill but w/e
+    intptr_t* null_checks = calloc(null_checks_size, sizeof(uintptr_t));
+
+    int num_null_checks = pattern_search(&text, 
+        null_check.bytes, null_check.mask, null_check.size,
+        null_checks, null_checks_size);
 
     int num_out = 0;
-    const uint8_t* addr = (const uint8_t*)reg->base;
-    const uint8_t* end = (const uint8_t*)(reg->base + reg->size - sizeof(aob));
-    for (; addr <= end; addr++) {
-        if (!matches_pattern(addr, aob, mask, sizeof(aob))) continue;
+    for (int i = 0; i < num_null_checks; i++) {
+        intptr_t candidate = null_checks[i];
 
-        // Read singleton address from MOV instruction relative offset
-        intptr_t s = (intptr_t)addr + 7 + *(uint32_t*)(addr + 3);
+        // Check if static address in data section
+        intptr_t static_addr = candidate + 7 + *(int32_t*)(candidate + 3);
+        if (!ptr_in_region(static_addr, &data)) continue;
 
-        int insert_at = bsearch_geq(s, out_array, num_out);
-        if (insert_at < num_out && out_array[insert_at] == s) continue;
+        // Check if runtime_class_ptr is in range
+        intptr_t runtime_class_ptr = candidate + 19 + *(int32_t*)(candidate + 15);
+        if (!ptr_in_region(runtime_class_ptr, &data)) continue;
 
-        // Shift elements above new one up one index to make space
-        for (int j = num_out - 1; j >= insert_at; --j)
-            out_array[j+1] = out_array[j];
-        out_array[insert_at] = s;
+        // Check if get_singleton_name function is in range
+        intptr_t get_singleton_name = candidate + 24 + *(int32_t*)(candidate + 20);
+        if (!ptr_in_region(get_singleton_name, &text)) continue;
 
-        if (++num_out == out_array_size)
-            break;
+        // Check if FD4Singleton header path is there
+        const char* filepath_ptr = (char*)(candidate + 46 + *(int32_t*)(candidate + 42));
+        if (!ptr_in_region(filepath_ptr, &rdata)) continue;
+
+        // Check if FD4Singleton path string ends with correct header name
+        size_t filepath_len = strnlen(filepath_ptr, 256);
+        if (filepath_len < 10 || filepath_len == 256) continue;
+        if (strcmp(filepath_ptr + filepath_len - 14, "FD4Singleton.h")) continue;
+
+        // Try to query the name
+        const char* name = ((char*(*)(intptr_t))get_singleton_name)(runtime_class_ptr);
+        if (!name) continue;
+
+        // Remove namespace from the name, if any
+        const char* simple_name = strrchr(name, ':') + 1;
+        if (!(simple_name-1)) simple_name = name;
+
+        // Check if address was already added, or we are out of space
+        if (num_out == out_array_size) break;
+        bool already_found = false;
+        for (int j = 0; j < num_out; j++) {
+            if (out_array[j].address != static_addr) continue;
+            already_found = true;
+            break; 
+        }
+        if (already_found) continue;
+
+        out_array[num_out].address = static_addr;
+        out_array[num_out].full_name = name;
+        out_array[num_out].simple_name = simple_name;
+        num_out++;
     }
+
+    free(null_checks);
+    pattern_destroy(&null_check);
     return num_out;
 }
 


### PR DESCRIPTION
Some people had problems with it taking a long time to run, timing out, etc. It was generally jank and relied on unreliable assumptions about how From splits their code in different translation units, and in what order their compiler/linker places static variables in memory. 

This version calls the game function present inside the null singleton checks to directly fetch the name of the singleton, no vtable shenanigans or potentially reading invalid memory needed. It should also run faster than the original. 

Since this version *only* finds `FD4Singleton` static addresses, some hardcoded AOBs (`GameMan` and `MsgRepository`) had to be re-enabled. 