### PR TITLE
Fix Currently Equipped Magic helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - "Unlock all Summoning Pools" thanks to [ivi](https://github.com/ividyon), also includes DLC summoning pools now
  - Session Info equipment for real
  - Focus, Stamina, Great Rune offsets
+ - Currently Equipped Magic helper shows correct spell more reliably
 
 ## [v1.13.0] - 2024-07-05
 ### Added


### PR DESCRIPTION
The Currently Equipped Magic helper is using a line of UI code which reads the mp value to update at present. This presents a problem as this is actually called up to 3 times - once for the current spell, and once for each spell in sequence after it, which makes the script unreliable and often points to a spell that is not the current one equipped.

I quickly rewrote it using a line that's checking if we have the stats (specifically Faith) to cast the spell instead, as it's more reliable. Even if the spell does not require Faith, this is still checked on every frame. Why Faith? I dunno, I honestly thought I had used Int. 

The last byte of the aob can be changed to 22 for requirementIntellect, or 0E for requirementLuck. The basic concept of the script is identical to the old one - snipe the base from a UI element. 


To be extra detailed, the current hook is checking whether or not the spell is greyed out due to failed mp requirements, which also show for the other spells in series. The new hook is checking if there should be a little red x on the spell icon, which actually only checks the current spell. Happy hacking!