### PR TITLE
Add script to automate Ranni's Rise fix

### DIFF
--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Helpers/Last Protector Highlighted/Start/Model Masks/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Helpers/Last Protector Highlighted/Start/Model Masks/.xml
@@ -6,7 +6,7 @@
   <ShowAsSigned>0</ShowAsSigned>
   <VariableType>Array of byte</VariableType>
   <ByteLength>0</ByteLength>
-  <Address>+130</Address>
+  <Address>+132</Address>
   <x-ce2fs-child-order>
     <id id="104709"/>
     <id id="104710"/>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
@@ -1,0 +1,67 @@
+{$lua}
+if syntaxcheck then return end
+[ENABLE]
+local flagsBaseOn = {
+-- Choosing to enter Ranni's service
+1034509410,
+1034509412,
+1034500738,
+1034500732,
+1034500736,
+1034505015,
+1034509361,
+1034500715,
+1034500710,
+1034500700,
+1034490701,
+1034490700,
+1034509413,
+1034509418,
+
+-- Exhausting Iji's dialogue in Ranni's Rise
+1034509355,
+1034509357,
+1034509358,
+
+-- Exhausting Blaidd's dialogue in Ranni's Rise
+1034509205,
+1045379208,
+
+-- Exhausting Seluvis' dialogue in Ranni's Rise
+1034509305,
+1034509306,
+
+-- Exhausting all 3 dialogues activating Ranni's next dialogue/step
+1034509417,
+1034500734,
+
+-- Exhausting Ranni's dialogue after talking to all 3 spirits
+1034509416,
+1034500739,
+1034500733,
+1034502610,
+1034505002,
+1034505003,
+1034505004,
+1034500716,
+1034503600,
+}
+
+local flagsOn = {flagsBaseOn}
+local flagsOff = 1034500738 -- Toggled on when choosing to enter, and off when exhausting dialogue
+ef.batchSetFlags(flagsOn, 1, "RanniFlagsThread")
+
+local t = createTimer(nil)
+t.interval = 100
+t.onTimer = function (t)
+    if function() return not ef.RanniFlagsThread end then
+        ef.setFlag(flagsOff, 0)
+        lua_warp(1034502950) -- [Liurnia of the Lakes] Ranni's Rise
+        t.destroy()
+    end
+end
+disableMemrec(memrec)
+
+[DISABLE]
+ef.RanniFlagsThread = false
+

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
@@ -63,3 +63,4 @@ t.onTimer = function (t)
 end
 [DISABLE]
 ef.RanniFlagsThread = false
+t.destroy()

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
@@ -56,12 +56,10 @@ t.interval = 100
 t.onTimer = function (t)
     if function() return not ef.RanniFlagsThread end then
         ef.setFlag(flagsOff, 0)
-        lua_warp(1034502950) -- [Liurnia of the Lakes] Ranni's Rise
+        -- lua_warp(1034502950) -- [Liurnia of the Lakes] Ranni's Rise. Not necessary, works instantly without it
         t.destroy()
+        disableMemrec(memrec)
     end
 end
-disableMemrec(memrec)
-
 [DISABLE]
 ef.RanniFlagsThread = false
-

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.xml
@@ -1,0 +1,5 @@
+<CheatEntry>
+  <ID>1987670845</ID>
+  <Description>"Ranni's Tower Fix"</Description>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>


### PR DESCRIPTION
Asking users to check and set 33 flags correctly is tedious. Here's a button to do it for you!
Also fixes model masks on Last Protector Highlighted, since it's off by 2.