### PR TITLE
Fixup: Don't overengineer the Ranni fix for no reason.

### DIFF
--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
@@ -49,8 +49,9 @@ local flagsBaseOn = {
 
 local flagsOn = {flagsBaseOn}
 local flagsOff = 1034500738 -- Toggled on when choosing to enter, and off when exhausting dialogue
-ef.batchSetFlags(flagsOn, 1, "RanniFlagsThread")
 ef.setFlag(flagsOff, 0)
+ef.batchSetFlags(flagsOn, 1, "RanniFlagsThread")
+
 
 disableMemrec(memrec, function() return not ef.RanniFlagsThread end)
 [DISABLE]

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
@@ -51,8 +51,7 @@ local flagsOn = {flagsBaseOn}
 local flagsOff = 1034500738 -- Toggled on when choosing to enter, and off when exhausting dialogue
 ef.setFlag(flagsOff, 0)
 ef.batchSetFlags(flagsOn, 1, "RanniFlagsThread")
-
-
 disableMemrec(memrec, function() return not ef.RanniFlagsThread end)
+
 [DISABLE]
 ef.RanniFlagsThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Scripts/Seamless Co-op/Ranni's Tower Fix.cea
@@ -5,7 +5,7 @@ local flagsBaseOn = {
 -- Choosing to enter Ranni's service
 1034509410,
 1034509412,
-1034500738,
+-- 1034500738, (needs to be disabled)
 1034500732,
 1034500736,
 1034505015,
@@ -50,16 +50,8 @@ local flagsBaseOn = {
 local flagsOn = {flagsBaseOn}
 local flagsOff = 1034500738 -- Toggled on when choosing to enter, and off when exhausting dialogue
 ef.batchSetFlags(flagsOn, 1, "RanniFlagsThread")
+ef.setFlag(flagsOff, 0)
 
-local t = createTimer(nil)
-t.interval = 100
-t.onTimer = function (t)
-    if function() return not ef.RanniFlagsThread end then
-        ef.setFlag(flagsOff, 0)
-        -- lua_warp(1034502950) -- [Liurnia of the Lakes] Ranni's Rise. Not necessary, works instantly without it
-        disableMemrec(memrec)
-    end
-end
+disableMemrec(memrec, function() return not ef.RanniFlagsThread end)
 [DISABLE]
 ef.RanniFlagsThread = false
-t.destroy()


### PR DESCRIPTION
The current Ranni fix does a bunch of unnecessary stuff, and fails to disable itself due to the timer being destroyed twice.
This fixes both. Mostly just housekeeping, to be honest, but it's bugged me.