### PR TITLE
Fix Teleport to Map-Relative Coordinates for Shadow of the Erdtree.

### DIFF
--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Coordinates & Teleport/Teleport to Map-Relative Coordinates/.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Coordinates & Teleport/Teleport to Map-Relative Coordinates/.cea
@@ -73,8 +73,7 @@ function getAbsoluteCoords(mapRelPos)
     for id, addr in pairs(worldMapLegacyConv) do
         local mapConv = readWorldMapLegacyConvParam(addr)
         if (mapConv.srcAreaNo == minfo.id and
-            mapConv.dstAreaNo == 0x3C or
-            mapConv.dstAreaNo == 0x3D and
+            (mapConv.dstAreaNo == 0x3C or mapConv.dstAreaNo == 0x3D) and
             mapConv.srcGridXNo == minfo.gridXNo and -- These aren't really grid coords,  more like dungeon number for the same type
             mapConv.srcGridZNo == minfo.gridZNo) then
             -- Perform conversion to open world coords by rebasing to open world map origin

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Coordinates & Teleport/Teleport to Map-Relative Coordinates/.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Coordinates & Teleport/Teleport to Map-Relative Coordinates/.cea
@@ -61,7 +61,7 @@ end
 function getAbsoluteCoords(mapRelPos)
     local minfo = getMapInfo(mapRelPos.map)
      -- 3C = open world map, divided in 256x256 chunks.
-    if (minfo.id == 0x3C) then
+    if (minfo.id == 0x3C or minfo.id == 0x3D) then
         return {
             x = mapRelPos.x + 256 * minfo.gridXNo,
             y = mapRelPos.y,
@@ -73,7 +73,8 @@ function getAbsoluteCoords(mapRelPos)
     for id, addr in pairs(worldMapLegacyConv) do
         local mapConv = readWorldMapLegacyConvParam(addr)
         if (mapConv.srcAreaNo == minfo.id and
-            mapConv.dstAreaNo == 0x3C and
+            mapConv.dstAreaNo == 0x3C or
+            mapConv.dstAreaNo == 0x3D and
             mapConv.srcGridXNo == minfo.gridXNo and -- These aren't really grid coords,  more like dungeon number for the same type
             mapConv.srcGridZNo == minfo.gridZNo) then
             -- Perform conversion to open world coords by rebasing to open world map origin


### PR DESCRIPTION
Now without a bunch of random unnecessary commits.
Shadow of the Erdtree uses the prefix 0x3D for its open-world maps, instead of the base game's 0x3C, causing map-relative teleports to break in its open world.
You can still get a broken teleport by trying to TP between the base game and DLC maps, but you could already accomplish that in several ways anyway so I wasn't too concerned with trying to fix it.