### PR TITLE
Fix "Filter Item Type" exploding ce2fs

### DIFF
--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Hero/EquipInventoryData/Filter Item Type.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Hero/EquipInventoryData/Filter Item Type.xml
@@ -1,20 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
-<CheatTable>
-	<CheatEntries>
-		<CheatEntry>
-			<ID>108257</ID>
-			<Description>"Filter Item Type"</Description>
-			<DropDownList ReadOnly="1" DescriptionOnly="1" DisplayValueAsItem="1">-1:All
+<CheatEntry>
+	<ID>106155</ID>
+	<Description>"Filter Item Type"</Description>
+	<DropDownList ReadOnly="1" DescriptionOnly="1" DisplayValueAsItem="1">-1:All
 0:Weapon only
 1:Protector only
 2:Accessory only
 4:Goods only
 8:Gem only
 </DropDownList>
-			<LastState Value="0" RealAddress="13FFC0005"/>
-			<ShowAsSigned>1</ShowAsSigned>
-			<VariableType>Byte</VariableType>
-			<Address>EquipInventoryDataIdx+5</Address>
-		</CheatEntry>
-	</CheatEntries>
-</CheatTable>
+	<LastState Value="0" RealAddress="13FFC0005"/>
+	<ShowAsSigned>1</ShowAsSigned>
+	<VariableType>Byte</VariableType>
+	<Address>EquipInventoryDataIdx+5</Address>
+</CheatEntry>
+


### PR DESCRIPTION
Looks like this entry was copy+pasted from CE and not sanitized, which was causing a stream of errors from ce2fs:
It has the `<CheatTable>` and `<CheatEntries>` tags, which should not be here,
It duplicates the ID 108257, which is also in the new GRAPHICS_OPTION dropdown,
The .xml for this folder references non-existent ID 106155, which I have assigned to this entry as I *assume* that was the intent all along.

Anyway, this PR un-crashes ce2fs so that the table will build again. :+1: 