### PR TITLE
Fix version check for versions exceeding 7.5 (Closes #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## [Unreleased]
+### Changed
+ - by [Umgak](https://github.com/Umgak):
+   - The Cheat Engine version check can now be skipped without crashing, and an option to disable the check is available
 ### Fixed
  - Removed ID `3252` (Loretta) from "Kill all mobs"
  - "Remove Seamless Co-op items" script

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/.cea
@@ -515,7 +515,7 @@ if tga.config.checkGameVersion and current_game_ver ~= game_ver then
     ))
 end
 
-if tga.config.checkCEVersion and getCEVersion() < ce_ver or getCEVersion() > ce_max_ver then
+if tga.config.checkCEVersion and (getCEVersion() < ce_ver or getCEVersion() > ce_max_ver) then
     local ver_str = string.format("Only Cheat Engine versions between %s and %s are officially supported by The Grand Archives.\nFuture versions are closed-source, and have not been checked for safety.\nWe provide instructions for installing 7.5 on our GitHub. Go there now?",ce_ver,ce_max_ver,ce_ver)
     local dl_url = string.format("https://github.com/The-Grand-Archives/Elden-Ring-CT-TGA?tab=readme-ov-file#installing-cheat-engine")
     if messageDialog("CE Version Check", ver_str, mtError, mbYes, mbNo)==mrYes then

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/.cea
@@ -516,12 +516,16 @@ if tga.config.checkGameVersion and current_game_ver ~= game_ver then
 end
 
 if tga.config.checkCEVersion and (getCEVersion() < ce_ver or getCEVersion() > ce_max_ver) then
-    local ver_str = string.format("Only Cheat Engine versions between %s and %s are officially supported by The Grand Archives.\nFuture versions are closed-source, and have not been checked for safety.\nWe provide instructions for installing 7.5 on our GitHub. Go there now?",ce_ver,ce_max_ver,ce_ver)
+    local ver_str = string.format("Only Cheat Engine versions between %s and %s are officially supported by The Grand Archives.\nFuture versions are closed-source, and have not been checked for safety.\nWe provide instructions for installing 7.5 on our GitHub. Go there now?\nCancel = No, and don't ask me again.",ce_ver,ce_max_ver,ce_ver)
     local dl_url = string.format("https://github.com/The-Grand-Archives/Elden-Ring-CT-TGA?tab=readme-ov-file#installing-cheat-engine")
-    if messageDialog("CE Version Check", ver_str, mtError, mbYes, mbNo)==mrYes then
+    result = messageDialog("CE Version Check", ver_str, mtError, mbYes, mbNo, mbCancel)
+    if result == mrYes then
         shellExecute(dl_url)
     end
-    error("Unsupported Cheat Engine version",2)
+    if result == mrCancel then
+        tga.config.checkCEVersion = false
+        tga:saveConfig()
+    end
 end
 
 if tga.config.checkTableVersion and table_ver ~= nil then


### PR DESCRIPTION
I always forget about parentheses in Lua. Never in any other language, for some reason.
Now, disabling the version check works no matter what version you have.