### PR TITLE
Adding Boss Revives & a skip Metyr's Questline script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,3 @@
 dist/
 CheatTable/Files/
 __pycache__
-/.vs/Elden-Ring-CT-TGA/CopilotIndices/17.14.1561.44479
-/.vs/Elden-Ring-CT-TGA/FileContentIndex
-/.vs/Elden-Ring-CT-TGA/v17/.wsuo
-/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.db
-/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.db-shm
-/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.db-wal
-/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.opendb
-/.vs/Elden-Ring-CT-TGA/v17/DocumentLayout.backup.json
-/.vs/Elden-Ring-CT-TGA/v17/DocumentLayout.json
-/.vs/Elden-Ring-CT-TGA/v17/workspaceFileList.bin
-/.vs/ProjectSettings.json
-/.vs/slnx.sqlite
-/.vs/slnx.sqlite-journal
-/.vs/VSWorkspaceState.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 dist/
 CheatTable/Files/
 __pycache__
+/.vs/Elden-Ring-CT-TGA/CopilotIndices/17.14.1561.44479
+/.vs/Elden-Ring-CT-TGA/FileContentIndex
+/.vs/Elden-Ring-CT-TGA/v17/.wsuo
+/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.db
+/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.db-shm
+/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.db-wal
+/.vs/Elden-Ring-CT-TGA/v17/Browse.VC.opendb
+/.vs/Elden-Ring-CT-TGA/v17/DocumentLayout.backup.json
+/.vs/Elden-Ring-CT-TGA/v17/DocumentLayout.json
+/.vs/Elden-Ring-CT-TGA/v17/workspaceFileList.bin
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite
+/.vs/slnx.sqlite-journal
+/.vs/VSWorkspaceState.json

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/.xml
@@ -10,5 +10,7 @@
     <id id="255"/>
     <id id="100604"/>
     <id id="106867"/>
+	<id id="1337318642"/>
+	<id id="1337318966"/>
   </x-ce2fs-child-order>
 </CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318642</ID>
+  <Description>"Boss Revive"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318641"/>
+    <id id="1337318834"/>
+    <id id="1337318861"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/.xml
@@ -1,0 +1,32 @@
+<CheatEntry>
+  <ID>1337318834</ID>
+  <Description>"Base Game"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318835"/>
+    <id id="1337318839"/>
+    <id id="1337318838"/>
+    <id id="1337318836"/>
+    <id id="1337318844"/>
+    <id id="1337318837"/>
+    <id id="1337318840"/>
+    <id id="1337318842"/>
+    <id id="1337318845"/>
+    <id id="1337318664"/>
+    <id id="1337318848"/>
+    <id id="1337318847"/>
+    <id id="1337318846"/>
+    <id id="1337318849"/>
+    <id id="1337318841"/>
+    <id id="1337318858"/>
+    <id id="1337318854"/>
+    <id id="1337318853"/>
+    <id id="1337318852"/>
+    <id id="1337318856"/>
+    <id id="1337318855"/>
+    <id id="1337318850"/>
+    <id id="1337318857"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Ainsel River/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Ainsel River/.xml
@@ -1,0 +1,10 @@
+<CheatEntry>
+  <ID>1337318844</ID>
+  <Description>"Ainsel River"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318752"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Ainsel River/Dragonkin Soldier of Nokstella.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Ainsel River/Dragonkin Soldier of Nokstella.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+12010801,
+-- Defeat Flags
+12010800,
+
+-- Reward Flags
+9109,
+510090,
+-- Extra Flags
+71210, -- Grace
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DragonSoldjahthewickedwhanThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DragonSoldjahSiofraThread")
+
+disableMemrec(memrec, function() return not ef.DragonSoldjahthewickedwhanThread end)
+
+[DISABLE]
+ef.DragonSoldjahthewickedwhanThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Ainsel River/Dragonkin Soldier of Nokstella.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Ainsel River/Dragonkin Soldier of Nokstella.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318752</ID>
+  <Description>"Dragonkin Soldier of Nokstella"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/.xml
@@ -1,0 +1,28 @@
+<CheatEntry>
+  <ID>1337318837</ID>
+  <Description>"Altus Plateau"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318682"/>
+    <id id="1337318683"/>
+    <id id="1337318716"/>
+    <id id="1337318715"/>
+    <id id="1337318733"/>
+    <id id="1337318745"/>
+    <id id="1337318760"/>
+    <id id="1337318767"/>
+    <id id="1337318768"/>
+    <id id="1337318776"/>
+    <id id="1337318778"/>
+    <id id="1337318792"/>
+    <id id="1337318798"/>
+    <id id="1337318804"/>
+    <id id="1337318807"/>
+    <id id="1337318821"/>
+    <id id="1337318825"/>
+    <id id="1337318831"/>
+    <id id="1337318830"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Dragon Lansseax.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Dragon Lansseax.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+1041520800,
+
+-- Reward Flags
+530300,
+
+-- Extra fixes
+
+}
+
+local flags = {flagsBase}
+
+local flagsToOne = {
+9290,
+}
+
+
+ef.batchSetFlags(flags, 0, "LansseaxThread")
+
+local flagsToOne = {}
+local flags2 = {flagsToOne}
+
+ --sleep(300)
+--ef.batchSetFlags(flags2, 1, "LansseaxThread")
+
+disableMemrec(memrec, function() return not ef.LansseaxThread end)
+
+[DISABLE]
+ef.LansseaxThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Dragon Lansseax.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Dragon Lansseax.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318682</ID>
+  <Description>"Ancient Dragon Lansseax"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Hero of Zamor (Altus).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Hero of Zamor (Altus).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30080800,
+
+-- Reward Flags
+9208,
+520080,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AncientHeroAThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "AncientHeroAThread")
+
+disableMemrec(memrec, function() return not ef.AncientHeroAThread end)
+
+[DISABLE]
+ef.AncientHeroAThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Hero of Zamor (Altus).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Ancient Hero of Zamor (Altus).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318683</ID>
+  <Description>"Ancient Hero of Zamor (Altus)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sage's Cave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sage's Cave).cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+31190800,
+
+-- Reward Flags
+9242,
+520420,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BKASageThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BKASageThread")
+
+disableMemrec(memrec, function() return not ef.BKASageThread end)
+
+[DISABLE]
+ef.BKASageThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sage's Cave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sage's Cave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318715</ID>
+  <Description>"Black Knife Assassin (Sage's Cave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sainted Hero's Grave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sainted Hero's Grave).cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1040520800,
+
+-- Reward Flags
+
+530350,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BKASaintedThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BKASaintedThread")
+
+disableMemrec(memrec, function() return not ef.BKASaintedThread end)
+
+[DISABLE]
+ef.BKASaintedThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sainted Hero's Grave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Black Knife Assassin (Sainted Hero's Grave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318716</ID>
+  <Description>"Black Knife Assassin (Sainted Hero's Grave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Crystalian Duo (Spear & Ringblade).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Crystalian Duo (Spear & Ringblade).cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+32050801,
+32058590,
+-- Defeat Flags
+32050800,
+
+-- Reward Flags
+9265,
+520650,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CrystalianDuoAltusThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CrystalianDuoAltusThread")
+
+disableMemrec(memrec, function() return not ef.CrystalianDuoAltusThread end)
+
+[DISABLE]
+ef.CrystalianDuoAltusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Crystalian Duo (Spear & Ringblade).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Crystalian Duo (Spear & Ringblade).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318733</ID>
+  <Description>"Crystalian Duo (Spear &amp; Ringblade)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Demi-Human Queen Gilika.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Demi-Human Queen Gilika.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1038510800,
+
+-- Reward Flags
+
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "GilikaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GilikaThread")
+
+disableMemrec(memrec, function() return not ef.GilikaThread end)
+
+[DISABLE]
+ef.GilikaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Demi-Human Queen Gilika.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Demi-Human Queen Gilika.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318745</ID>
+  <Description>"Demi-Human Queen Gilika"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Elemer of the Briar.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Elemer of the Briar.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1039540800,
+
+-- Reward Flags
+9182,
+510820,
+-- Extra Flags
+76322,
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ElemerThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ElemerThread")
+
+disableMemrec(memrec, function() return not ef.ElemerThread end)
+
+[DISABLE]
+ef.ElemerThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Elemer of the Briar.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Elemer of the Briar.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318760</ID>
+  <Description>"Elemer of the Briar"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Esgar, Priest of Blood.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Esgar, Priest of Blood.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+35000850,
+
+-- Reward Flags
+9222,
+520220,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "EsgarThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "EsgarThread")
+
+disableMemrec(memrec, function() return not ef.EsgarThread end)
+
+[DISABLE]
+ef.EsgarThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Esgar, Priest of Blood.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Esgar, Priest of Blood.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318767</ID>
+  <Description>"Esgar, Priest of Blood"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Fallingstar Beast (Altus).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Fallingstar Beast (Altus).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1041500800,
+
+-- Reward Flags
+530310,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "FSBAThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "FSBAThread")
+
+disableMemrec(memrec, function() return not ef.FSBAThread end)
+
+[DISABLE]
+ef.FSBAThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Fallingstar Beast (Altus).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Fallingstar Beast (Altus).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318768</ID>
+  <Description>"Fallingstar Beast (Altus)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godefroy the Grafted.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godefroy the Grafted.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1039500800,
+
+-- Reward Flags
+
+1039507100,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "GodefroyThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GodefroyThread")
+
+disableMemrec(memrec, function() return not ef.GodefroyThread end)
+
+[DISABLE]
+ef.GodefroyThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godefroy the Grafted.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godefroy the Grafted.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318776</ID>
+  <Description>"Godefroy the Grafted"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godskin Apostle (Altus).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godskin Apostle (Altus).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1042550800,
+
+-- Reward Flags
+530325,
+-- Extra Flags
+76313,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ApossumAltusThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ApossumDBThread")
+
+disableMemrec(memrec, function() return not ef.ApossumAltusThread end)
+
+[DISABLE]
+ef.ApossumAltusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godskin Apostle (Altus).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Godskin Apostle (Altus).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318778</ID>
+  <Description>"Godskin Apostle (Altus)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Necromancer Garris.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Necromancer Garris.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+
+-- Defeat Flags
+31190850,
+
+-- Reward Flags
+9249,
+520490,
+-- Extra Flags
+
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "GarryThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GarryThread")
+
+disableMemrec(memrec, function() return not ef.GarryThread end)
+
+[DISABLE]
+ef.GarryThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Necromancer Garris.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Necromancer Garris.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318792</ID>
+  <Description>"Necromancer Garris"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Night's Cavalry (Altus Plateau).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Night's Cavalry (Altus Plateau).cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1039510800,
+
+-- Reward Flags
+1039517200,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCAltusThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCAltusThread")
+
+disableMemrec(memrec, function() return not ef.NCAltusThread end)
+
+[DISABLE]
+ef.NCAltusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Night's Cavalry (Altus Plateau).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Night's Cavalry (Altus Plateau).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318798</ID>
+  <Description>"Night's Cavalry (Altus Plateau)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Omenkiller & Miranda the Blighted Bloom.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Omenkiller & Miranda the Blighted Bloom.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31180800,
+
+-- Reward Flags
+9241,
+520410,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "OmerandaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "OmerandaThread")
+
+disableMemrec(memrec, function() return not ef.OmerandaThread end)
+
+[DISABLE]
+ef.OmerandaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Omenkiller & Miranda the Blighted Bloom.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Omenkiller & Miranda the Blighted Bloom.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318804</ID>
+  <Description>"Omenkiller &amp; Miranda the Blighted Bloom"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Perfumer Tricia & Misbegotten Warrior.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Perfumer Tricia & Misbegotten Warrior.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30120800,
+
+-- Reward Flags
+9211,
+520110,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "TriciaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "TriciaThread")
+
+disableMemrec(memrec, function() return not ef.TriciaThread end)
+
+[DISABLE]
+ef.TriciaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Perfumer Tricia & Misbegotten Warrior.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Perfumer Tricia & Misbegotten Warrior.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318807</ID>
+  <Description>"Perfumer Tricia &amp; Misbegotten Warrior"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Stonedigger Troll (Old Altus Tunnel).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Stonedigger Troll (Old Altus Tunnel).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+32040800,
+
+-- Reward Flags
+9263,
+520630,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "StoneDiggerAltusThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "StoneDiggerAltusThread")
+
+disableMemrec(memrec, function() return not ef.StoneDiggerAltusThread end)
+
+[DISABLE]
+ef.StoneDiggerAltusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Stonedigger Troll (Old Altus Tunnel).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Stonedigger Troll (Old Altus Tunnel).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318821</ID>
+  <Description>"Stonedigger Troll (Old Altus Tunnel)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tibia Mariner (Altus Plateau).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tibia Mariner (Altus Plateau).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+1038520800,
+
+-- Reward Flags
+530385,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "BoatAThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "BoatAThread")
+
+disableMemrec(memrec, function() return not ef.BoatAThread end)
+
+[DISABLE]
+ef.BoatAThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tibia Mariner (Altus Plateau).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tibia Mariner (Altus Plateau).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318825</ID>
+  <Description>"Tibia Mariner (Altus Plateau)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tree Sentinel Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tree Sentinel Duo.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+1041510800,
+
+-- Reward Flags
+530335,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "TSDuoThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "TSDuoThread")
+
+disableMemrec(memrec, function() return not ef.TSDuoThread end)
+
+[DISABLE]
+ef.TSDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tree Sentinel Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Tree Sentinel Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318831</ID>
+  <Description>"Tree Sentinel Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Wormface.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Wormface.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+1041530800,
+
+-- Reward Flags
+65060,
+65000,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "WormfaceThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "WormfaceThread")
+
+disableMemrec(memrec, function() return not ef.WormfaceThread end)
+
+[DISABLE]
+ef.WormfaceThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Wormface.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Altus Plateau/Wormface.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318830</ID>
+  <Description>"Wormface"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/.xml
@@ -1,0 +1,23 @@
+<CheatEntry>
+  <ID>1337318848</ID>
+  <Description>"Caelid"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318648"/>
+    <id id="1337318723"/>
+    <id id="1337318727"/>
+    <id id="1337318731"/>
+    <id id="1337318738"/>
+    <id id="1337318743"/>
+    <id id="1337318759"/>
+    <id id="1337318762"/>
+    <id id="1337318766"/>
+    <id id="1337318772"/>
+    <id id="1337318780"/>
+    <id id="1337318787"/>
+    <id id="1337318796"/>
+    <id id="1337318802"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Cemetery Shade (Caelid).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Cemetery Shade (Caelid).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30150800,
+
+-- Reward Flags
+9215,
+520150,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ShadeCThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "ShadeCThread")
+
+disableMemrec(memrec, function() return not ef.ShadeCThread end)
+
+[DISABLE]
+ef.ShadeCThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Cemetery Shade (Caelid).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Cemetery Shade (Caelid).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318723</ID>
+  <Description>"Cemetery Shade (Caelid)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Commander O'Neil.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Commander O'Neil.cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1049380800,
+
+-- Reward Flags
+530405,
+-- Extra Flags
+76412,
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "OneilThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "OneilThread")
+
+disableMemrec(memrec, function() return not ef.OneilThread end)
+
+[DISABLE]
+ef.OneilThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Commander O'Neil.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Commander O'Neil.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318727</ID>
+  <Description>"Commander O'Neil"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Crucible Knight & Misbegotten Warrior.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Crucible Knight & Misbegotten Warrior.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1051360800,
+
+-- Reward Flags
+9183,
+510830,
+-- Extra Flags
+76419,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CruciMisbegottenThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CruciMisbegottenThread")
+
+disableMemrec(memrec, function() return not ef.CruciMisbegottenThread end)
+
+[DISABLE]
+ef.CruciMisbegottenThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Crucible Knight & Misbegotten Warrior.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Crucible Knight & Misbegotten Warrior.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318731</ID>
+  <Description>"Crucible Knight &amp; Misbegotten Warrior"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Death Rite Bird (Caelid).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Death Rite Bird (Caelid).cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1049370850,
+
+-- Reward Flags
+1049377110,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DRBCaeThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "DRBCaeThread")
+
+disableMemrec(memrec, function() return not ef.DRBCaeThread end)
+
+[DISABLE]
+ef.DRBCaeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Death Rite Bird (Caelid).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Death Rite Bird (Caelid).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318738</ID>
+  <Description>"Death Rite Bird (Caelid)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Decaying Ekzykes.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Decaying Ekzykes.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1048370800,
+
+-- Reward Flags
+530400,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "EkzykesThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "EkzykesThread")
+
+disableMemrec(memrec, function() return not ef.EkzykesThread end)
+
+[DISABLE]
+ef.EkzykesThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Decaying Ekzykes.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Decaying Ekzykes.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318743</ID>
+  <Description>"Decaying Ekzykes"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Erdtree Burial Watchdog Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Erdtree Burial Watchdog Duo.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30140800,
+
+-- Reward Flags
+9214,
+520140,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "WatchdogDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "WatchdogDuoThread")
+
+disableMemrec(memrec, function() return not ef.WatchdogDuoThread end)
+
+[DISABLE]
+ef.WatchdogDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Erdtree Burial Watchdog Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Erdtree Burial Watchdog Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318762</ID>
+  <Description>"Erdtree Burial Watchdog Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Fallingstar Beast (Sellia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Fallingstar Beast (Sellia).cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+32088590,
+32080801,
+-- Defeat Flags
+32080800,
+
+-- Reward Flags
+9267,
+520670,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "FSBSThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "FSBSThread")
+
+disableMemrec(memrec, function() return not ef.FSBSThread end)
+
+[DISABLE]
+ef.FSBSThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Fallingstar Beast (Sellia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Fallingstar Beast (Sellia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318766</ID>
+  <Description>"Fallingstar Beast (Sellia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Frenzied Duelist.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Frenzied Duelist.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+31210801,
+-- Defeat Flags
+31210800,
+
+-- Reward Flags
+9243,
+520430,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "FrenziedDuelistThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "FrenziedDuelistThread")
+
+disableMemrec(memrec, function() return not ef.FrenziedDuelistThread end)
+
+[DISABLE]
+ef.FrenziedDuelistThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Frenzied Duelist.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Frenzied Duelist.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318772</ID>
+  <Description>"Frenzied Duelist"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Mad Pumpkinhead Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Mad Pumpkinhead Duo.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1048400800,
+
+-- Reward Flags
+
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PumpkinDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PumpkinDuoThread")
+
+disableMemrec(memrec, function() return not ef.PumpkinDuoThread end)
+
+[DISABLE]
+ef.PumpkinDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Mad Pumpkinhead Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Mad Pumpkinhead Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318780</ID>
+  <Description>"Mad Pumpkinhead Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Magma Wyrm (Gael Tunnel).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Magma Wyrm (Gael Tunnel).cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+32070800,
+
+-- Reward Flags
+9266,
+520660,
+-- Extra Flags
+
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MagmuhCaeThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MagmuhCaeThread")
+
+disableMemrec(memrec, function() return not ef.MagmuhCaeThread end)
+
+[DISABLE]
+ef.MagmuhCaeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Magma Wyrm (Gael Tunnel).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Magma Wyrm (Gael Tunnel).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318787</ID>
+  <Description>"Magma Wyrm (Gael Tunnel)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Night's Cavalry (Caelid).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Night's Cavalry (Caelid).cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1049370800,
+
+-- Reward Flags
+1049377100,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCCaeThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCCaeThread")
+
+disableMemrec(memrec, function() return not ef.NCCaeThread end)
+
+[DISABLE]
+ef.NCCaeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Night's Cavalry (Caelid).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Night's Cavalry (Caelid).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318796</ID>
+  <Description>"Night's Cavalry (Caelid)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Nox Swordstress & Nox Monk.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Nox Swordstress & Nox Monk.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1049390800,
+
+-- Reward Flags
+1049397800,
+-- Extra Flags
+76415,
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NoxDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NoxDuoThread")
+
+disableMemrec(memrec, function() return not ef.NoxDuoThread end)
+
+[DISABLE]
+ef.NoxDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Nox Swordstress & Nox Monk.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Nox Swordstress & Nox Monk.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318802</ID>
+  <Description>"Nox Swordstress &amp; Nox Monk"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Putrid Avatar (Caelid).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Putrid Avatar (Caelid).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1047400800,
+
+-- Reward Flags
+65100,
+65280,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarRotviewThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarRotviewThread")
+
+disableMemrec(memrec, function() return not ef.AvatarRotviewThread end)
+
+[DISABLE]
+ef.AvatarRotviewThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Putrid Avatar (Caelid).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Putrid Avatar (Caelid).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318759</ID>
+  <Description>"Putrid Avatar (Caelid)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Starscourge Radahn.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Starscourge Radahn.cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- Jerran's "CHAMPIONS! WELCOME!" to unlock the door
+3367,
+
+-- Teleport Blaidd back to the Plaza for no aggro
+3613,
+
+-- Teleport Alexander back to the Plaza for no aggro
+3668,
+
+-- Remove grace from the unlocked list
+76422,
+
+-- Fix Festival Shit
+9412,
+
+-- Boss Start
+1252380801, -- First Encounter?
+1252382810, -- Boss Appears Flag
+
+
+-- Boss Death
+1252380800, -- Death Flag
+9130, -- Wait until Radahn is dead
+510300, -- Remembrance Reward
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "SSRThread")
+disableMemrec(memrec, function() return not ef.SSRThread end)
+
+[DISABLE]
+ef.SSRThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Starscourge Radahn.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Caelid/Starscourge Radahn.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318648</ID>
+  <Description>"Starscourge Radahn"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/.xml
@@ -1,0 +1,15 @@
+<CheatEntry>
+  <ID>1337318842</ID>
+  <Description>"Capital Outskirts"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318710"/>
+    <id id="1337318730"/>
+    <id id="1337318740"/>
+    <id id="1337318782"/>
+    <id id="1337318805"/>
+    <id id="1337318650"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Bell Bearing Hunter (Capital Outskirts).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Bell Bearing Hunter (Capital Outskirts).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 1 (Reload area with Quitout, TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1043530800,
+
+-- Reward Flags
+1043537400,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BBHAThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BBHAThread")
+
+disableMemrec(memrec, function() return not ef.BBHAThread end)
+
+[DISABLE]
+ef.BBHAThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Bell Bearing Hunter (Capital Outskirts).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Bell Bearing Hunter (Capital Outskirts).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318710</ID>
+  <Description>"Bell Bearing Hunter (Capital Outskirts)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Crucible Knight & Crucible Knight Ordovis.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Crucible Knight & Crucible Knight Ordovis.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30100800,
+
+-- Reward Flags
+9210,
+520100,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CruciDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CruciDuoThread")
+
+disableMemrec(memrec, function() return not ef.CruciDuoThread end)
+
+[DISABLE]
+ef.CruciDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Crucible Knight & Crucible Knight Ordovis.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Crucible Knight & Crucible Knight Ordovis.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318730</ID>
+  <Description>"Crucible Knight &amp; Crucible Knight Ordovis"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Deathbird (Capital Outskirts).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Deathbird (Capital Outskirts).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1044530800,
+
+-- Reward Flags
+1044537300,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DBCOThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DBCOThread")
+
+disableMemrec(memrec, function() return not ef.DBCOThread end)
+
+[DISABLE]
+ef.DBCOThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Deathbird (Capital Outskirts).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Deathbird (Capital Outskirts).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318740</ID>
+  <Description>"Deathbird (Capital Outskirts)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Draconic Tree Sentinel.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Draconic Tree Sentinel.cea
@@ -1,0 +1,22 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+
+-- Boss Death
+1045520800,
+
+--Reward Stuff
+9290, -- Wait until Boss is dead
+530315, -- Dragon Claw and Shield
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "DTSThread")
+disableMemrec(memrec, function() return not ef.DTSThread end)
+
+[DISABLE]
+ef.DTSThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Draconic Tree Sentinel.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Draconic Tree Sentinel.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318650</ID>
+  <Description>"Draconic Tree Sentinel"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Grave Warden Duelist (Capital Outskirts).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Grave Warden Duelist (Capital Outskirts).cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30130800,
+
+-- Reward Flags
+9213,
+
+-- Extra Flags
+520130,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PumpkinDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PumpkinDuoThread")
+
+disableMemrec(memrec, function() return not ef.PumpkinDuoThread end)
+
+[DISABLE]
+ef.PumpkinDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Grave Warden Duelist (Capital Outskirts).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Grave Warden Duelist (Capital Outskirts).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318782</ID>
+  <Description>"Grave Warden Duelist (Capital Outskirts)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Onyx Lord (Capital Outskirts).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Onyx Lord (Capital Outskirts).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+34120801,
+-- Defeat Flags
+34120800,
+
+-- Reward Flags
+9264,
+520640,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "OnyxTunnelThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "OnyxTunnelThread")
+
+disableMemrec(memrec, function() return not ef.OnyxTunnelThread end)
+
+[DISABLE]
+ef.OnyxTunnelThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Onyx Lord (Capital Outskirts).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Capital Outskirts/Onyx Lord (Capital Outskirts).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318805</ID>
+  <Description>"Onyx Lord (Capital Outskirts)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/.xml
@@ -1,0 +1,17 @@
+<CheatEntry>
+  <ID>1337318841</ID>
+  <Description>"Consecrated Snowfields"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318705"/>
+    <id id="1337318736"/>
+    <id id="1337318783"/>
+    <id id="1337318791"/>
+    <id id="1337318794"/>
+    <id id="1337318757"/>
+    <id id="1337318810"/>
+    <id id="1337318822"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Astel, Stars of Darkness.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Astel, Stars of Darkness.cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+32110801,
+-- Defeat Flags
+32110800,
+
+-- Reward Flags
+9268,
+520680,
+-- Extra Flags
+32110590, -- Door
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MegaAstelThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "MegaAstelThread")
+
+disableMemrec(memrec, function() return not ef.MegaAstelThread end)
+
+[DISABLE]
+ef.MegaAstelThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Astel, Stars of Darkness.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Astel, Stars of Darkness.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318705</ID>
+  <Description>"Astel, Stars of Darkness"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Death Rite Bird (Consecrated Snowfield).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Death Rite Bird (Consecrated Snowfield).cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1048570800,
+
+-- Reward Flags
+1048577700,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DRBCSThread")
+
+-- Extra section if I need flags set to 1
+
+local flagsToOne = {
+1247580400, -- Turns off angry mausoleum
+}
+
+local flags2 = {flagsToOne}
+
+sleep(200)
+
+ef.batchSetFlags(flags2, 1, "DRBCSThread")
+
+disableMemrec(memrec, function() return not ef.DRBCSThread end)
+
+[DISABLE]
+ef.DRBCSThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Death Rite Bird (Consecrated Snowfield).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Death Rite Bird (Consecrated Snowfield).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318736</ID>
+  <Description>"Death Rite Bird (Consecrated Snowfield)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Great Wyrm Theodorix.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Great Wyrm Theodorix.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1050560800,
+
+-- Reward Flags
+530550,
+
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "TheodorixThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "TheodorixThread")
+
+disableMemrec(memrec, function() return not ef.TheodorixThread end)
+
+[DISABLE]
+ef.TheodorixThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Great Wyrm Theodorix.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Great Wyrm Theodorix.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318783</ID>
+  <Description>"Great Wyrm Theodorix"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Misbegotten Crusader.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Misbegotten Crusader.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+
+-- Defeat Flags
+31120800,
+
+-- Reward Flags
+9247,
+520470,
+-- Extra Flags
+
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CrusaderThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "CrusaderThread")
+
+disableMemrec(memrec, function() return not ef.CrusaderThread end)
+
+[DISABLE]
+ef.CrusaderThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Misbegotten Crusader.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Misbegotten Crusader.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318791</ID>
+  <Description>"Misbegotten Crusader"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Night's Cavalry Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Night's Cavalry Duo.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1248550800,
+
+-- Reward Flags
+1048557710,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCDuoThread")
+
+disableMemrec(memrec, function() return not ef.NCDuoThread end)
+
+[DISABLE]
+ef.NCDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Night's Cavalry Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Night's Cavalry Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318794</ID>
+  <Description>"Night's Cavalry Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Avatar (Consecrated Snowfield).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Avatar (Consecrated Snowfield).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1050570850,
+
+-- Reward Flags
+65130,
+65170,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarCSThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarCSThread")
+
+disableMemrec(memrec, function() return not ef.AvatarCSThread end)
+
+[DISABLE]
+ef.AvatarCSThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Avatar (Consecrated Snowfield).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Avatar (Consecrated Snowfield).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318757</ID>
+  <Description>"Putrid Avatar (Consecrated Snowfield)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Grave Warden Duelist.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Grave Warden Duelist.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30190800,
+
+-- Reward Flags
+9219,
+520190,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PutriDuelistThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PutriDuelistThread")
+
+disableMemrec(memrec, function() return not ef.PutriDuelistThread end)
+
+[DISABLE]
+ef.PutriDuelistThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Grave Warden Duelist.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Putrid Grave Warden Duelist.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318810</ID>
+  <Description>"Putrid Grave Warden Duelist"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Stray Mimic Tear.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Stray Mimic Tear.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+30200800,
+
+-- Reward Flags
+9220,
+520200,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "StrayMimicThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "StrayMimicThread")
+
+disableMemrec(memrec, function() return not ef.StrayMimicThread end)
+
+[DISABLE]
+ef.StrayMimicThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Stray Mimic Tear.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Consecrated Snowfields/Stray Mimic Tear.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318822</ID>
+  <Description>"Stray Mimic Tear"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318854</ID>
+  <Description>"Crumbling Farum Azula"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318689"/>
+    <id id="1337318691"/>
+    <id id="1337318645"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Dragonlord Placidusax.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Dragonlord Placidusax.cea
@@ -1,0 +1,29 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+13000830,
+-- Reward Flags
+9115,
+510150,
+
+71301,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "PlaciThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "PlaciThread")
+
+disableMemrec(memrec, function() return not ef.PlaciThread end)
+
+[DISABLE]
+ef.PlaciThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Dragonlord Placidusax.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Dragonlord Placidusax.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318691</ID>
+  <Description>"Dragonlord Placidusax"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Godskin Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Godskin Duo.cea
@@ -1,0 +1,30 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+13000851,
+
+-- Defeat Flags
+
+13000850,
+-- Reward Flags
+9114,
+510140,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GduoThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "GduoThread")
+
+disableMemrec(memrec, function() return not ef.GduoThread end)
+
+[DISABLE]
+ef.GduoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Godskin Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Godskin Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318689</ID>
+  <Description>"Godskin Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Maliketh, the Black Blade.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Maliketh, the Black Blade.cea
@@ -1,0 +1,24 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+13003700,
+13002805,
+9365, --Dialogue stuff
+13009205, --Dialogue stuff
+13002120, -- Dialogue stuff
+13000801, -- First Encounter
+13000800, -- Death Flag
+9116, -- Wait until boss is dead for reward
+510160, -- Reward
+71300, -- Disable Grace
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MalikethThread")
+disableMemrec(memrec, function() return not ef.MalikethThread end)
+
+[DISABLE]
+ef.MalikethThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Maliketh, the Black Blade.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Crumbling Farum Azula/Maliketh, the Black Blade.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318645</ID>
+  <Description>"Maliketh, the Black Blade"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318858</ID>
+  <Description>"Deeproot Depths"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318701"/>
+    <id id="1337318694"/>
+    <id id="1337318729"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Crucible Knight Siluria.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Crucible Knight Siluria.cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+12030390,
+
+-- Reward Flags
+12037950,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "SiluriaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "SiluriaThread")
+
+disableMemrec(memrec, function() return not ef.SiluriaThread end)
+
+[DISABLE]
+ef.SiluriaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Crucible Knight Siluria.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Crucible Knight Siluria.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318729</ID>
+  <Description>"Crucible Knight Siluria"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Fia's Champions.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Fia's Champions.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+12030801,
+
+-- Defeat Flags
+12030800,
+-- Reward Flags
+9135,
+510350,
+-- Extra
+71230,
+4138,
+4139,
+4128,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "FiasThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "FiasThread")
+
+disableMemrec(memrec, function() return not ef.FiasThread end)
+
+[DISABLE]
+ef.FiasThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Fia's Champions.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Fia's Champions.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318701</ID>
+  <Description>"Fia's Champions"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Lichdragon Fortissax.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Lichdragon Fortissax.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+12030850,
+-- Reward Flags
+9111,
+510110,
+-- Extra
+4131,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "FortiThread")
+
+local flagsToOne = {
+4130,
+}
+ local flags2 = {flagsToOne}
+ sleep(200)
+ ef.batchSetFlags(flags2, 1, "FortiThread")
+
+disableMemrec(memrec, function() return not ef.FortiThread end)
+
+[DISABLE]
+ef.FortiThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Lichdragon Fortissax.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Deeproot Depths/Lichdragon Fortissax.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318694</ID>
+  <Description>"Lichdragon Fortissax"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318846</ID>
+  <Description>"Forbidden Lands"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318713"/>
+    <id id="1337318797"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Black Blade Kindred (Forbidden Lands).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Black Blade Kindred (Forbidden Lands).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1049520800,
+
+-- Reward Flags
+530505,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BBKFLThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BBKFLThread")
+
+disableMemrec(memrec, function() return not ef.BBKFLThread end)
+
+[DISABLE]
+ef.BBKFLThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Black Blade Kindred (Forbidden Lands).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Black Blade Kindred (Forbidden Lands).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318713</ID>
+  <Description>"Black Blade Kindred (Forbidden Lands)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Night's Cavalry (Forbidden Lands).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Night's Cavalry (Forbidden Lands).cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1048510800,
+
+-- Reward Flags
+1048517700,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCFLThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCFLThread")
+
+disableMemrec(memrec, function() return not ef.NCFLThread end)
+
+[DISABLE]
+ef.NCFLThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Night's Cavalry (Forbidden Lands).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Forbidden Lands/Night's Cavalry (Forbidden Lands).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318797</ID>
+  <Description>"Night's Cavalry (Forbidden Lands)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/.xml
@@ -1,0 +1,20 @@
+<CheatEntry>
+  <ID>1337318847</ID>
+  <Description>"Greyoll's Dragonbarrow"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318706"/>
+    <id id="1337318707"/>
+    <id id="1337318711"/>
+    <id id="1337318712"/>
+    <id id="1337318726"/>
+    <id id="1337318773"/>
+    <id id="1337318777"/>
+    <id id="1337318795"/>
+    <id id="1337318758"/>
+    <id id="1337318808"/>
+    <id id="1337318809"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Battlemage Hugues.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Battlemage Hugues.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1049390850,
+
+-- Reward Flags
+1049397850,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "HugeThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "HugeThread")
+
+disableMemrec(memrec, function() return not ef.HugeThread end)
+
+[DISABLE]
+ef.HugeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Battlemage Hugues.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Battlemage Hugues.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318706</ID>
+  <Description>"Battlemage Hugues"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Beastman of Farum Azula (Duo).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Beastman of Farum Azula (Duo).cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 1 (Reload area with Quitout, TT or warp to a grace)
+
+-- First Encounter Flags
+31100801,
+-- Defeat Flags
+31100800,
+
+-- Reward Flags
+9244,
+520440,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BeastmanDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BeastmanDuoThread")
+
+disableMemrec(memrec, function() return not ef.BeastmanDuoThread end)
+
+[DISABLE]
+ef.BeastmanDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Beastman of Farum Azula (Duo).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Beastman of Farum Azula (Duo).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318707</ID>
+  <Description>"Beastman of Farum Azula (Duo)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Bell Bearing Hunter (Dragonbarrow).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Bell Bearing Hunter (Dragonbarrow).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 1 (Reload area with Quitout, TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1048410800,
+
+-- Reward Flags
+1048417800,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BBHDBThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BBHDBThread")
+
+disableMemrec(memrec, function() return not ef.BBHDBThread end)
+
+[DISABLE]
+ef.BBHDBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Bell Bearing Hunter (Dragonbarrow).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Bell Bearing Hunter (Dragonbarrow).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318711</ID>
+  <Description>"Bell Bearing Hunter (Dragonbarrow)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Black Blade Kindred (Dragonbarrow).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Black Blade Kindred (Dragonbarrow).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1051430800,
+
+-- Reward Flags
+530425,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BBKDBThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BBKDBThread")
+
+disableMemrec(memrec, function() return not ef.BBKDBThread end)
+
+[DISABLE]
+ef.BBKDBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Black Blade Kindred (Dragonbarrow).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Black Blade Kindred (Dragonbarrow).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318712</ID>
+  <Description>"Black Blade Kindred (Dragonbarrow)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Cleanrot Knight Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Cleanrot Knight Duo.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31200800,
+
+-- Reward Flags
+9245,
+520450,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CleanrotDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CleanrotDuoThread")
+
+disableMemrec(memrec, function() return not ef.CleanrotDuoThread end)
+
+[DISABLE]
+ef.CleanrotDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Cleanrot Knight Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Cleanrot Knight Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318726</ID>
+  <Description>"Cleanrot Knight Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Flying Dragon Greyll.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Flying Dragon Greyll.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1052410800,
+
+-- Reward Flags
+
+530420,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "GreyllThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GreyllThread")
+
+disableMemrec(memrec, function() return not ef.GreyllThread end)
+
+[DISABLE]
+ef.GreyllThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Flying Dragon Greyll.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Flying Dragon Greyll.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318773</ID>
+  <Description>"Flying Dragon Greyll"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Godskin Apostle (Dragonbarrow).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Godskin Apostle (Dragonbarrow).cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+34130800,
+
+-- Reward Flags
+9173,
+510730,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ApossumDBThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ApossumDBThread")
+
+disableMemrec(memrec, function() return not ef.ApossumDBThread end)
+
+[DISABLE]
+ef.ApossumDBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Godskin Apostle (Dragonbarrow).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Godskin Apostle (Dragonbarrow).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318777</ID>
+  <Description>"Godskin Apostle (Dragonbarrow)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Night's Cavalry (Dragonbarrow).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Night's Cavalry (Dragonbarrow).cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1052410850,
+
+-- Reward Flags
+1052417100,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCGDThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCGDThread")
+
+disableMemrec(memrec, function() return not ef.NCGDThread end)
+
+[DISABLE]
+ef.NCGDThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Night's Cavalry (Dragonbarrow).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Night's Cavalry (Dragonbarrow).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318795</ID>
+  <Description>"Night's Cavalry (Dragonbarrow)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Avatar (Greyoll's Dragonbarrow).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Avatar (Greyoll's Dragonbarrow).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1051400800,
+
+-- Reward Flags
+65110,
+65260,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarDBThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarDBThread")
+
+disableMemrec(memrec, function() return not ef.AvatarDBThread end)
+
+[DISABLE]
+ef.AvatarDBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Avatar (Greyoll's Dragonbarrow).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Avatar (Greyoll's Dragonbarrow).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318758</ID>
+  <Description>"Putrid Avatar (Greyoll's Dragonbarrow)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Crystalian Trio.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Crystalian Trio.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31110800,
+
+-- Reward Flags
+9246,
+520460,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PutriCrystalThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PutriCrystalThread")
+
+disableMemrec(memrec, function() return not ef.PutriCrystalThread end)
+
+[DISABLE]
+ef.PutriCrystalThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Crystalian Trio.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Crystalian Trio.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318808</ID>
+  <Description>"Putrid Crystalian Trio"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Tree Spirit.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Tree Spirit.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30160800,
+
+-- Reward Flags
+9216,
+520160,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PutriSpiritThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PutriSpiritThread")
+
+disableMemrec(memrec, function() return not ef.PutriSpiritThread end)
+
+[DISABLE]
+ef.PutriSpiritThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Tree Spirit.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Greyoll's Dragonbarrow/Putrid Tree Spirit.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318809</ID>
+  <Description>"Putrid Tree Spirit"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318856</ID>
+  <Description>"Lake of Rot"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318686"/>
+    <id id="1337318751"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Astel, Naturalborn of the Void.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Astel, Naturalborn of the Void.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+12040800,
+
+-- Reward Flags
+9108,
+510080,
+-- Extra Flags
+71240,
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "RemAstelThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "RemAstelThread")
+
+disableMemrec(memrec, function() return not ef.RemAstelThread end)
+
+[DISABLE]
+ef.RemAstelThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Astel, Naturalborn of the Void.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Astel, Naturalborn of the Void.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318686</ID>
+  <Description>"Astel, Naturalborn of the Void"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Dragonkin Soldier (Lake of Rot).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Dragonkin Soldier (Lake of Rot).cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+12010850,
+
+-- Reward Flags
+
+530600,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DragonSoldjahLoRThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DragonSoldjahLoRThread")
+
+disableMemrec(memrec, function() return not ef.DragonSoldjahLoRThread end)
+
+[DISABLE]
+ef.DragonSoldjahLoRThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Dragonkin Soldier (Lake of Rot).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Lake of Rot/Dragonkin Soldier (Lake of Rot).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318751</ID>
+  <Description>"Dragonkin Soldier (Lake of Rot)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318853</ID>
+  <Description>"Leyndell, Ashen Capital"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318647"/>
+    <id id="1337318692"/>
+    <id id="1337318688"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Hoarah Loux, Warrior.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Hoarah Loux, Warrior.cea
@@ -1,0 +1,30 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+11050801,
+
+-- Defeat Flags
+11050800,
+-- Reward Flags
+9107,
+510070,
+
+71301,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "HLThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "HLThread")
+
+disableMemrec(memrec, function() return not ef.HLThread end)
+
+[DISABLE]
+ef.HLThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Hoarah Loux, Warrior.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Hoarah Loux, Warrior.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318692</ID>
+  <Description>"Hoarah Loux, Warrior"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Radagon of the Golden Order  Elden Beast.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Radagon of the Golden Order  Elden Beast.cea
@@ -1,0 +1,46 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+19000800,
+
+-- Reward Flags
+9123,
+510230,
+-- Extra Flags
+19002810,
+19000800,
+19001100,
+19000804,
+19005014,
+19005013,
+19005011,
+19005000,
+19002800,
+71900,
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "RadabeastThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "RadabeastThread")
+
+disableMemrec(memrec, function() return not ef.RadabeastThread end)
+
+[DISABLE]
+ef.RadabeastThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Radagon of the Golden Order  Elden Beast.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Radagon of the Golden Order  Elden Beast.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318688</ID>
+  <Description>"Radagon of the Golden Order / Elden Beast"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Sir Gideon Ofnir, the All-Knowing.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Sir Gideon Ofnir, the All-Knowing.cea
@@ -1,0 +1,19 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+11050851, -- First Encounter
+11050850, -- Death Flag
+9106, -- Wait until boss is dead for reward
+510060, -- Reward
+71121, -- Grace
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GideonThread")
+disableMemrec(memrec, function() return not ef.GideonThread end)
+
+[DISABLE]
+ef.GideonThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Sir Gideon Ofnir, the All-Knowing.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Ashen Capital/Sir Gideon Ofnir, the All-Knowing.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318647</ID>
+  <Description>"Sir Gideon Ofnir, the All-Knowing"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318845</ID>
+  <Description>"Leyndell, Royal Capital"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318657"/>
+    <id id="1337318698"/>
+    <id id="1337318770"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Fell Twins.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Fell Twins.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+34140851,
+-- Defeat Flags
+34140850,
+
+-- Reward Flags
+9174,
+510740,
+-- Extra Flags
+34140865,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "FellTwinsThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "FellTwinsThread")
+
+disableMemrec(memrec, function() return not ef.FellTwinsThread end)
+
+[DISABLE]
+ef.FellTwinsThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Fell Twins.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Fell Twins.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318770</ID>
+  <Description>"Fell Twins"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Godfrey, the First Elden Lord (Golden Shade).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Godfrey, the First Elden Lord (Golden Shade).cea
@@ -1,0 +1,27 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+11000851,
+-- Defeat Flags
+11000850,
+-- Reward Flags
+9105,
+60520,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GoldfreyThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "GoldfreyThread")
+
+disableMemrec(memrec, function() return not ef.GoldfreyThread end)
+
+[DISABLE]
+ef.GoldfreyThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Godfrey, the First Elden Lord (Golden Shade).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Godfrey, the First Elden Lord (Golden Shade).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318657</ID>
+  <Description>"Godfrey, the First Elden Lord (Golden Shade)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Morgott, the Omen King.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Morgott, the Omen King.cea
@@ -1,0 +1,42 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+11000801,
+
+-- Defeat Flags
+11000800,
+
+-- Reward Flags
+9104,
+510040,
+
+-- Remove Grace from warp list
+71100,
+
+-- Restore Fogwall
+11000501,
+
+-- Needed to remove grace
+11000500,
+11005000,
+11002500,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MorgannyThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MorgannyThread")
+
+disableMemrec(memrec, function() return not ef.MorgannyThread end)
+
+[DISABLE]
+ef.MorgannyThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Morgott, the Omen King.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Leyndell, Royal Capital/Morgott, the Omen King.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318698</ID>
+  <Description>"Morgott, the Omen King"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/.xml
@@ -1,0 +1,28 @@
+<CheatEntry>
+  <ID>1337318835</ID>
+  <Description>"Limgrave"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318644"/>
+    <id id="1337318640"/>
+    <id id="1337318708"/>
+    <id id="1337318714"/>
+    <id id="1337318704"/>
+    <id id="1337318728"/>
+    <id id="1337318739"/>
+    <id id="1337318744"/>
+    <id id="1337318761"/>
+    <id id="1337318771"/>
+    <id id="1337318779"/>
+    <id id="1337318781"/>
+    <id id="1337318784"/>
+    <id id="1337318801"/>
+    <id id="1337318833"/>
+    <id id="1337318818"/>
+    <id id="1337318678"/>
+    <id id="1337318823"/>
+    <id id="1337318828"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bell Bearing Hunter (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bell Bearing Hunter (Limgrave).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 1 (Reload area with Quitout, TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1042380850,
+
+-- Reward Flags
+1042387410,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BBHLimThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BBHLimThread")
+
+disableMemrec(memrec, function() return not ef.BBHLimThread end)
+
+[DISABLE]
+ef.BBHLimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bell Bearing Hunter (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bell Bearing Hunter (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318708</ID>
+  <Description>"Bell Bearing Hunter (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Black Knife Assassin (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Black Knife Assassin (Limgrave).cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+30110800,
+
+-- Reward Flags
+9203,
+520030,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BKALimThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BKALimThread")
+
+disableMemrec(memrec, function() return not ef.BKALimThread end)
+
+[DISABLE]
+ef.BKALimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Black Knife Assassin (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Black Knife Assassin (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318714</ID>
+  <Description>"Black Knife Assassin (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bloodhound Knight (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bloodhound Knight (Limgrave).cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1044350800,
+
+-- Reward Flags
+530130,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BKLimThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BKLimThread")
+
+disableMemrec(memrec, function() return not ef.BKLimThread end)
+
+[DISABLE]
+ef.BKLimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bloodhound Knight (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Bloodhound Knight (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318704</ID>
+  <Description>"Bloodhound Knight (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Crucible Knight.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Crucible Knight.cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1042370800,
+
+-- Reward Flags
+530120,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CrucibleThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CrucibleThread")
+
+disableMemrec(memrec, function() return not ef.CrucibleThread end)
+
+[DISABLE]
+ef.CrucibleThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Crucible Knight.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Crucible Knight.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318728</ID>
+  <Description>"Crucible Knight"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Deathbird (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Deathbird (Limgrave).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1042380800,
+
+-- Reward Flags
+1042387400,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DBLimThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DBLimThread")
+
+disableMemrec(memrec, function() return not ef.DBLimThread end)
+
+[DISABLE]
+ef.DBLimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Deathbird (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Deathbird (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318739</ID>
+  <Description>"Deathbird (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Demi-Human Chiefs.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Demi-Human Chiefs.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+31150815,
+-- Defeat Flags
+31150800,
+
+-- Reward Flags
+9234,
+520340,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ChiefsThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ChiefsThread")
+
+disableMemrec(memrec, function() return not ef.ChiefsThread end)
+
+[DISABLE]
+ef.ChiefsThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Demi-Human Chiefs.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Demi-Human Chiefs.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318744</ID>
+  <Description>"Demi-Human Chiefs"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Erdtree Burial Watchdog (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Erdtree Burial Watchdog (Limgrave).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30020800,
+
+-- Reward Flags
+9202,
+520020,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "WatchdogLimThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "WatchdogLimThread")
+
+disableMemrec(memrec, function() return not ef.WatchdogLimThread end)
+
+[DISABLE]
+ef.WatchdogLimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Erdtree Burial Watchdog (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Erdtree Burial Watchdog (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318761</ID>
+  <Description>"Erdtree Burial Watchdog (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Flying Dragon Agheel.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Flying Dragon Agheel.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+1043360340,
+-- Defeat Flags
+1043360800,
+
+-- Reward Flags
+
+530110,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AgheelThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AgheelThread")
+
+disableMemrec(memrec, function() return not ef.AgheelThread end)
+
+[DISABLE]
+ef.AgheelThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Flying Dragon Agheel.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Flying Dragon Agheel.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318771</ID>
+  <Description>"Flying Dragon Agheel"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Godrick the Grafted.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Godrick the Grafted.cea
@@ -1,0 +1,26 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+3269, -- Remvoe Gostoc from Arena
+3265, -- Move Gostoc to Original Location
+10000720, -- Remove Godrick's Dead Body
+10000800, -- Godrick the Grafted
+10000801, -- Godrick Cutscene
+10002802, -- Godrick Phase 2
+9101,
+61101,
+510010,
+9391,
+9304,
+71000, -- Grace
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GodrickThread")
+disableMemrec(memrec, function() return not ef.GodrickThread end)
+
+[DISABLE]
+ef.GodrickThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Godrick the Grafted.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Godrick the Grafted.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318640</ID>
+  <Description>"Godrick the Grafted"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Grave Warden Duelist (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Grave Warden Duelist (Limgrave).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30040800,
+
+-- Reward Flags
+9204,
+520040,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PumpkinDuoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PumpkinDuoThread")
+
+disableMemrec(memrec, function() return not ef.PumpkinDuoThread end)
+
+[DISABLE]
+ef.PumpkinDuoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Grave Warden Duelist (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Grave Warden Duelist (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318781</ID>
+  <Description>"Grave Warden Duelist (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Guardian Golem.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Guardian Golem.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31170800,
+
+-- Reward Flags
+9235,
+
+-- Extra Flags
+520350,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "GGThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GGThread")
+
+disableMemrec(memrec, function() return not ef.GGThread end)
+
+[DISABLE]
+ef.GGThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Guardian Golem.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Guardian Golem.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318784</ID>
+  <Description>"Guardian Golem"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Mad Pumpkinhead.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Mad Pumpkinhead.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1044360800,
+
+-- Reward Flags
+
+-- Extra Flags
+76120,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "PumpkinThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PumpkinThread")
+
+disableMemrec(memrec, function() return not ef.PumpkinThread end)
+
+[DISABLE]
+ef.PumpkinThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Mad Pumpkinhead.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Mad Pumpkinhead.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318779</ID>
+  <Description>"Mad Pumpkinhead"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Margit, the Fell Omen.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Margit, the Fell Omen.cea
@@ -1,0 +1,19 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+10000851, -- First Encounter
+10000850, -- Margit Death Flag
+9100, -- Wait until Margit is dead to give reward
+60510, -- Talisman Pouch
+71001, -- Grace
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MargitThread")
+disableMemrec(memrec, function() return not ef.MargitThread end)
+
+[DISABLE]
+ef.MargitThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Margit, the Fell Omen.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Margit, the Fell Omen.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318644</ID>
+  <Description>"Margit, the Fell Omen"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Night's Cavalry (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Night's Cavalry (Limgrave).cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+
+-- Defeat Flags
+1043370800,
+
+-- Reward Flags
+1043377400,
+-- Extra Flags
+
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCLimThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCLimThread")
+
+disableMemrec(memrec, function() return not ef.NCLimThread end)
+
+[DISABLE]
+ef.NCLimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Night's Cavalry (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Night's Cavalry (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318801</ID>
+  <Description>"Night's Cavalry (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Patches.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Patches.cea
@@ -1,0 +1,53 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+31008521, -- chest
+31003702, -- fight flag?
+31008821, -- hp bar?
+31009210, -- yap?
+-- Defeat Flags
+31000800,
+3683, -- revive if dead
+-- Reward Flags
+9232,
+400183,
+400189,
+520320,
+
+-- Get rid of npc patches from the arena
+3680,
+3686,
+
+--fix patches showing up earlier than he should if you make him angry after surrender
+31008820,
+
+
+
+}
+
+
+local flagsToOne = {
+
+-- First Encounter stuff
+3682,
+3685,
+
+}
+
+local flags = {flagsBase}
+
+local flags2 = {flagsToOne}
+
+ef.batchSetFlags(flags, 0, "PatchesThread")
+
+sleep(1400)
+
+ef.batchSetFlags(flags2, 1, "PatchesThread")
+
+disableMemrec(memrec, function() return not ef.PatchesThread end)
+
+[DISABLE]
+ef.PatchesThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Patches.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Patches.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318833</ID>
+  <Description>"Patches"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Soldier of Godrick.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Soldier of Godrick.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+18000850,
+
+-- Reward Flags
+
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "SoGThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "SoGThread")
+
+disableMemrec(memrec, function() return not ef.SoGThread end)
+
+[DISABLE]
+ef.SoGThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Soldier of Godrick.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Soldier of Godrick.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318818</ID>
+  <Description>"Soldier of Godrick"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Stonedigger Troll (Limgrave Tunnel).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Stonedigger Troll (Limgrave Tunnel).cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+32018590, -- door
+32010801, --
+
+-- Defeat Flags
+32010800,
+
+-- Reward Flags
+9261,
+520610,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "StoneDiggerLimgraveThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "StoneDiggerLimgraveThread")
+
+disableMemrec(memrec, function() return not ef.StoneDiggerLimgraveThread end)
+
+[DISABLE]
+ef.StoneDiggerLimgraveThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Stonedigger Troll (Limgrave Tunnel).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Stonedigger Troll (Limgrave Tunnel).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318678</ID>
+  <Description>"Stonedigger Troll (Limgrave Tunnel)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Tibia Mariner (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Tibia Mariner (Limgrave).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+1045390800,
+
+-- Reward Flags
+530170,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "BoatLimThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "BoatLimThread")
+
+disableMemrec(memrec, function() return not ef.BoatLimThread end)
+
+[DISABLE]
+ef.BoatLimThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Tibia Mariner (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Tibia Mariner (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318823</ID>
+  <Description>"Tibia Mariner (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Ulcerated Tree Spirit (Limgrave).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Ulcerated Tree Spirit (Limgrave).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+18000800,
+
+-- Reward Flags
+9128,
+510280,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "SpiritLThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "SpiritLThread")
+
+disableMemrec(memrec, function() return not ef.SpiritLThread end)
+
+[DISABLE]
+ef.SpiritLThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Ulcerated Tree Spirit (Limgrave).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Limgrave/Ulcerated Tree Spirit (Limgrave).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318828</ID>
+  <Description>"Ulcerated Tree Spirit (Limgrave)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/.xml
@@ -1,0 +1,35 @@
+<CheatEntry>
+  <ID>1337318836</ID>
+  <Description>"Liurnia of the Lakes"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318649"/>
+    <id id="1337318643"/>
+    <id id="1337318709"/>
+    <id id="1337318718"/>
+    <id id="1337318719"/>
+    <id id="1337318720"/>
+    <id id="1337318724"/>
+    <id id="1337318725"/>
+    <id id="1337318732"/>
+    <id id="1337318734"/>
+    <id id="1337318741"/>
+    <id id="1337318735"/>
+    <id id="1337318755"/>
+    <id id="1337318756"/>
+    <id id="1337318764"/>
+    <id id="1337318775"/>
+    <id id="1337318665"/>
+    <id id="1337318789"/>
+    <id id="1337318800"/>
+    <id id="1337318799"/>
+    <id id="1337318803"/>
+    <id id="1337318806"/>
+    <id id="1337318703"/>
+    <id id="1337318814"/>
+    <id id="1337318817"/>
+    <id id="1337318824"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bell Bearing Hunter (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bell Bearing Hunter (Liurnia).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 1 (Reload area with Quitout, TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+1037460800,
+
+-- Reward Flags
+1037467400,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BBHLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BBHLThread")
+
+disableMemrec(memrec, function() return not ef.BBHLiuThread end)
+
+[DISABLE]
+ef.BBHLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bell Bearing Hunter (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bell Bearing Hunter (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318709</ID>
+  <Description>"Bell Bearing Hunter (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Black Knife Assassin (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Black Knife Assassin (Liurnia).cea
@@ -1,0 +1,39 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- InitializeDeadInit = 0 (Reload area with TT or warp to a grace)
+
+-- First Encounter Flags
+
+-- Defeat Flags
+30050850,
+
+-- Reward Flags
+9221,
+520210,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BKALiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BKALiuThread")
+
+disableMemrec(memrec, function() return not ef.BKALiuThread end)
+
+[DISABLE]
+ef.BKALiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Black Knife Assassin (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Black Knife Assassin (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318718</ID>
+  <Description>"Black Knife Assassin (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bloodhound Knight (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bloodhound Knight (Liurnia).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+31050801,
+-- Defeat Flags
+31050800,
+
+-- Reward Flags
+9237,
+520370,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BKLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BKLiuThread")
+
+disableMemrec(memrec, function() return not ef.BKLiuThread end)
+
+[DISABLE]
+ef.BKLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bloodhound Knight (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bloodhound Knight (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318719</ID>
+  <Description>"Bloodhound Knight (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bols, Carian Knight.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bols, Carian Knight.cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1033450800,
+
+-- Reward Flags
+530250,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BallsThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BallsThread")
+
+disableMemrec(memrec, function() return not ef.BallsThread end)
+
+[DISABLE]
+ef.BallsThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bols, Carian Knight.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Bols, Carian Knight.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318720</ID>
+  <Description>"Bols, Carian Knight"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cemetery Shade (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cemetery Shade (Liurnia).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30050800,
+
+-- Reward Flags
+9205,
+520050,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ShadeLThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "ShadeWPThread")
+
+disableMemrec(memrec, function() return not ef.ShadeLThread end)
+
+[DISABLE]
+ef.ShadeLThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cemetery Shade (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cemetery Shade (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318724</ID>
+  <Description>"Cemetery Shade (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cleanrot Knight (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cleanrot Knight (Liurnia).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31040800,
+
+-- Reward Flags
+9236,
+520360,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CleanrotLThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CleanrotLThread")
+
+disableMemrec(memrec, function() return not ef.CleanrotLThread end)
+
+[DISABLE]
+ef.CleanrotLThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cleanrot Knight (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Cleanrot Knight (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318725</ID>
+  <Description>"Cleanrot Knight (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian Duo (Spear & Staff).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian Duo (Spear & Staff).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31060800,
+
+-- Reward Flags
+9238,
+520380,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CrystalianDuoLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CrystalianDuoLiuThread")
+
+disableMemrec(memrec, function() return not ef.CrystalianDuoLiuThread end)
+
+[DISABLE]
+ef.CrystalianDuoLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian Duo (Spear & Staff).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian Duo (Spear & Staff).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318734</ID>
+  <Description>"Crystalian Duo (Spear &amp; Staff)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+32020800,
+
+-- Reward Flags
+9262,
+520620,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CrystalianThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "CrystalianThread")
+
+disableMemrec(memrec, function() return not ef.CrystalianThread end)
+
+[DISABLE]
+ef.CrystalianThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Crystalian.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318732</ID>
+  <Description>"Crystalian "</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Death Rite Bird (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Death Rite Bird (Liurnia).cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1036450800,
+
+-- Reward Flags
+1036457400,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DRBLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "DRBLiuThread")
+
+disableMemrec(memrec, function() return not ef.DRBLiuThread end)
+
+[DISABLE]
+ef.DRBLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Death Rite Bird (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Death Rite Bird (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318735</ID>
+  <Description>"Death Rite Bird (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Deathbird (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Deathbird (Liurnia).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1037420800,
+
+-- Reward Flags
+1037427400,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DBLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DBLiuThread")
+
+disableMemrec(memrec, function() return not ef.DBLiuThread end)
+
+[DISABLE]
+ef.DBLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Deathbird (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Deathbird (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318741</ID>
+  <Description>"Deathbird (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Northeast Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Northeast Liurnia).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1038480800,
+
+-- Reward Flags
+65290,
+65300,
+65310,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarNELiurniaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarNELiurniaThread")
+
+disableMemrec(memrec, function() return not ef.AvatarNELiurniaThread end)
+
+[DISABLE]
+ef.AvatarNELiurniaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Northeast Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Northeast Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318755</ID>
+  <Description>"Erdtree Avatar (Northeast Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Southwest Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Southwest Liurnia).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1033430800,
+
+-- Reward Flags
+65040,
+65160,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarSWLiurniaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarSWLiurniaThread")
+
+disableMemrec(memrec, function() return not ef.AvatarSWLiurniaThread end)
+
+[DISABLE]
+ef.AvatarSWLiurniaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Southwest Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Avatar (Southwest Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318756</ID>
+  <Description>"Erdtree Avatar (Southwest Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Burial Watchdog (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Burial Watchdog (Liurnia).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30060800,
+
+-- Reward Flags
+9207,
+520070,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "WatchdogLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "WatchdogLiuThread")
+
+disableMemrec(memrec, function() return not ef.WatchdogLiuThread end)
+
+[DISABLE]
+ef.WatchdogLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Burial Watchdog (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Erdtree Burial Watchdog (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318764</ID>
+  <Description>"Erdtree Burial Watchdog (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Glintstone Dragon Smarag.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Glintstone Dragon Smarag.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1034450800,
+
+-- Reward Flags
+
+530210,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "SmaragThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "SmaragThread")
+
+disableMemrec(memrec, function() return not ef.SmaragThread end)
+
+[DISABLE]
+ef.SmaragThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Glintstone Dragon Smarag.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Glintstone Dragon Smarag.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318775</ID>
+  <Description>"Glintstone Dragon Smarag"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Grafted Scion.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Grafted Scion.cea
@@ -1,0 +1,17 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+10010800, -- Death Flag
+9103, -- Wait until boss is dead to give reward
+510030, -- Reward
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "ScionThread")
+disableMemrec(memrec, function() return not ef.ScionThread end)
+
+[DISABLE]
+ef.ScionThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Grafted Scion.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Grafted Scion.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318665</ID>
+  <Description>"Grafted Scion"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Magma Wyrm Makar.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Magma Wyrm Makar.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+39200801,
+
+-- Defeat Flags
+39200800,
+
+-- Reward Flags
+9126,
+510260,
+-- Extra Flags
+
+73900,
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MakarThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MakarThread")
+
+disableMemrec(memrec, function() return not ef.MakarThread end)
+
+[DISABLE]
+ef.MakarThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Magma Wyrm Makar.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Magma Wyrm Makar.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318789</ID>
+  <Description>"Magma Wyrm Makar"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (North Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (North Liurnia).cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1036480800,
+
+-- Reward Flags
+1036487400,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCNLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCNLiuThread")
+
+disableMemrec(memrec, function() return not ef.NCNLiuThread end)
+
+[DISABLE]
+ef.NCNLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (North Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (North Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318799</ID>
+  <Description>"Night's Cavalry (North Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (South Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (South Liurnia).cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1039430800,
+
+-- Reward Flags
+1039437400,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCSLiuThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCSLiuThread")
+
+disableMemrec(memrec, function() return not ef.NCSLiuThread end)
+
+[DISABLE]
+ef.NCSLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (South Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Night's Cavalry (South Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318800</ID>
+  <Description>"Night's Cavalry (South Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Omenkiller.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Omenkiller.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1035420800,
+
+-- Reward Flags
+530225,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "OmenkillahThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "OmenkillahThread")
+
+disableMemrec(memrec, function() return not ef.OmenkillahThread end)
+
+[DISABLE]
+ef.OmenkillahThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Omenkiller.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Omenkiller.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318803</ID>
+  <Description>"Omenkiller"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Onyx Lord (Liurnia).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Onyx Lord (Liurnia).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1036500800,
+
+-- Reward Flags
+
+530255,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "OnyxEvergaolThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "OnyxEvergaolThread")
+
+disableMemrec(memrec, function() return not ef.OnyxEvergaolThread end)
+
+[DISABLE]
+ef.OnyxEvergaolThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Onyx Lord (Liurnia).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Onyx Lord (Liurnia).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318806</ID>
+  <Description>"Onyx Lord (Liurnia)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Red Wolf of Radagon.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Red Wolf of Radagon.cea
@@ -1,0 +1,27 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+14000851,
+
+-- Boss Death
+14000850,
+
+--Reward Stuff
+9117, -- Wait until Boss is dead
+60440, -- Memory Stone
+
+-- Remove grace from the unlocked list
+71401,
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RedWolfofRadagonThread")
+disableMemrec(memrec, function() return not ef.RedWolfofRadagonThread end)
+
+[DISABLE]
+ef.RedWolfofRadagonThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Red Wolf of Radagon.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Red Wolf of Radagon.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318649</ID>
+  <Description>"Red Wolf of Radagon"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Rennala, Queen of the Full Moon.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Rennala, Queen of the Full Moon.cea
@@ -1,0 +1,25 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+14008556, -- Door
+14000800, -- Rennala
+14000801, -- Rennala Cutscene
+177, -- Player Reward
+197, -- Player Reward
+61118, -- Warp Related Flag
+14000804, -- Mark the end of the fight P2
+14003915, -- Remove Test Dummy
+9118, -- Remove NPC Rennala
+14000702, -- NPC Rennala Talk event
+14002800, -- Rennala Defeat Flag
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RennalaThread")
+disableMemrec(memrec, function() return not ef.RennalaThread end)
+
+[DISABLE]
+ef.GodrickThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Rennala, Queen of the Full Moon.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Rennala, Queen of the Full Moon.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318643</ID>
+  <Description>"Rennala, Queen of the Full Moon"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Knight Loretta.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Knight Loretta.cea
@@ -1,0 +1,30 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+1035500801,
+
+-- Defeat Flags
+1035500800,
+-- Reward Flags
+9181,
+510810,
+-- Extra
+76232,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RKRThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "RKRThread")
+
+disableMemrec(memrec, function() return not ef.RKRThread end)
+
+[DISABLE]
+ef.RKRThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Knight Loretta.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Knight Loretta.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318703</ID>
+  <Description>"Royal Knight Loretta"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Revenant.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Revenant.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1034480800,
+
+-- Reward Flags
+
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "RevThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RevThread")
+
+disableMemrec(memrec, function() return not ef.RevThread end)
+
+[DISABLE]
+ef.RevThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Revenant.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Royal Revenant.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318814</ID>
+  <Description>"Royal Revenant"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Spirit-Caller Snail (Crucible Knight).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Spirit-Caller Snail (Crucible Knight).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30030800,
+
+-- Reward Flags
+9206,
+520060,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "CKSnailThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "CKSnailThread")
+
+disableMemrec(memrec, function() return not ef.CKSnailThread end)
+
+[DISABLE]
+ef.CKSnailThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Spirit-Caller Snail (Crucible Knight).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Spirit-Caller Snail (Crucible Knight).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318817</ID>
+  <Description>"Spirit-Caller Snail (Crucible Knight)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Tibia Mariner (Liurnia of the Lakes).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Tibia Mariner (Liurnia of the Lakes).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+1039440800,
+
+-- Reward Flags
+530240,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "BoatLiuThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "BoatLiuThread")
+
+disableMemrec(memrec, function() return not ef.BoatLiuThread end)
+
+[DISABLE]
+ef.BoatLiuThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Tibia Mariner (Liurnia of the Lakes).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Liurnia of the Lakes/Tibia Mariner (Liurnia of the Lakes).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318824</ID>
+  <Description>"Tibia Mariner (Liurnia of the Lakes)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318850</ID>
+  <Description>"Miquella's Haligtree"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318695"/>
+    <id id="1337318697"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Loretta, Knight of the Haligtree.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Loretta, Knight of the Haligtree.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+15000851,
+-- Defeat Flags
+15000850,
+-- Reward Flags
+9119,
+510190,
+-- Extra
+71505,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "LorettaThread")
+
+--local flagsToOne = {
+--4130,
+--}
+-- local flags2 = {flagsToOne}
+-- sleep(200)
+--ef.batchSetFlags(flags2, 1, "LorettaThread")
+
+disableMemrec(memrec, function() return not ef.LorettaThread end)
+
+[DISABLE]
+ef.LorettaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Loretta, Knight of the Haligtree.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Loretta, Knight of the Haligtree.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318695</ID>
+  <Description>"Loretta, Knight of the Haligtree"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Malenia, Blade of Miquella.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Malenia, Blade of Miquella.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+15000801,
+-- Defeat Flags
+15000800,
+-- Reward Flags
+9120,
+510200,
+-- Extra
+71500,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MareniaThread")
+
+--local flagsToOne = {
+--4130,
+--}
+-- local flags2 = {flagsToOne}
+-- sleep(200)
+--ef.batchSetFlags(flags2, 1, "MareniaThread")
+
+disableMemrec(memrec, function() return not ef.MareniaThread end)
+
+[DISABLE]
+ef.MareniaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Malenia, Blade of Miquella.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Miquella's Haligtree/Malenia, Blade of Miquella.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318697</ID>
+  <Description>"Malenia, Blade of Miquella"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mohgwyn's Dynasty/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mohgwyn's Dynasty/.xml
@@ -1,0 +1,10 @@
+<CheatEntry>
+  <ID>1337318857</ID>
+  <Description>"Mohgwyn's Dynasty"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318700"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mohgwyn's Dynasty/Mohg, Lord of Blood.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mohgwyn's Dynasty/Mohg, Lord of Blood.cea
@@ -1,0 +1,42 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+12050801,
+
+-- Defeat Flags
+12050800,
+
+-- Reward Flags
+9112,
+510120,
+
+-- Remove Grace from warp list
+71250,
+
+-- remove leda, hopefully
+12050700,
+12050750,
+12059261,
+4440,
+4445,
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "AmohgusThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AmohgusThread")
+
+disableMemrec(memrec, function() return not ef.AmohgusThread end)
+
+[DISABLE]
+ef.AmohgusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mohgwyn's Dynasty/Mohg, Lord of Blood.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mohgwyn's Dynasty/Mohg, Lord of Blood.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318700</ID>
+  <Description>"Mohg, Lord of Blood"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318855</ID>
+  <Description>"Moonlight Plateau"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318774"/>
+    <id id="1337318859"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Alecto, Black Knife Ringleader.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Alecto, Black Knife Ringleader.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1033420800,
+
+-- Reward Flags
+
+530265,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AlectoThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AlectoThread")
+
+disableMemrec(memrec, function() return not ef.AlectoThread end)
+
+[DISABLE]
+ef.AlectoThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Alecto, Black Knife Ringleader.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Alecto, Black Knife Ringleader.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318774</ID>
+  <Description>"Alecto, Black Knife Ringleader"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Glintstone Dragon Adula.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Glintstone Dragon Adula.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1034420800,
+
+-- Reward Flags
+
+530260,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AdulaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AdulaThread")
+
+disableMemrec(memrec, function() return not ef.AdulaThread end)
+
+[DISABLE]
+ef.AdulaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Glintstone Dragon Adula.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Moonlight Plateau/Glintstone Dragon Adula.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318859</ID>
+  <Description>"Glintstone Dragon Adula"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/.xml
@@ -1,0 +1,18 @@
+<CheatEntry>
+  <ID>1337318849</ID>
+  <Description>"Mountaintops of the Giants"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318687"/>
+    <id id="1337318690"/>
+    <id id="1337318684"/>
+    <id id="1337318721"/>
+    <id id="1337318737"/>
+    <id id="1337318754"/>
+    <id id="1337318812"/>
+    <id id="1337318820"/>
+    <id id="1337318829"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ancient Hero of Zamor (Mountaintops).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ancient Hero of Zamor (Mountaintops).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30170800,
+
+-- Reward Flags
+9217,
+520170,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AncientHeroMThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "AncientHeroMThread")
+
+disableMemrec(memrec, function() return not ef.AncientHeroMThread end)
+
+[DISABLE]
+ef.AncientHeroMThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ancient Hero of Zamor (Mountaintops).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ancient Hero of Zamor (Mountaintops).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318684</ID>
+  <Description>"Ancient Hero of Zamor (Mountaintops)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Borealis the Freezing Fog.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Borealis the Freezing Fog.cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1254560800,
+
+-- Reward Flags
+530510,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "BorealisThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "BorealisThread")
+
+disableMemrec(memrec, function() return not ef.BorealisThread end)
+
+[DISABLE]
+ef.BorealisThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Borealis the Freezing Fog.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Borealis the Freezing Fog.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318721</ID>
+  <Description>"Borealis the Freezing Fog"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Commander Niall.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Commander Niall.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+1051570801,
+-- Defeat Flags
+1051570800,
+
+-- Reward Flags
+9184,
+510840,
+-- Extra Flags
+76524,
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NiallThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "RemAstelThread")
+
+disableMemrec(memrec, function() return not ef.NiallThread end)
+
+[DISABLE]
+ef.NiallThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Commander Niall.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Commander Niall.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318687</ID>
+  <Description>"Commander Niall"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Death Rite Bird (Mountaintops of the Giants).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Death Rite Bird (Mountaintops of the Giants).cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1050570800,
+
+-- Reward Flags
+530530,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DRBMotGThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "DRBMotGThread")
+
+disableMemrec(memrec, function() return not ef.DRBMotGThread end)
+
+[DISABLE]
+ef.DRBMotGThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Death Rite Bird (Mountaintops of the Giants).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Death Rite Bird (Mountaintops of the Giants).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318737</ID>
+  <Description>"Death Rite Bird (Mountaintops of the Giants)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Erdtree Avatar (Mountaintops of the Giants).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Erdtree Avatar (Mountaintops of the Giants).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1052560800,
+
+-- Reward Flags
+65050,
+65070,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarMountainThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarMountainThread")
+
+disableMemrec(memrec, function() return not ef.AvatarMountainThread end)
+
+[DISABLE]
+ef.AvatarMountainThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Erdtree Avatar (Mountaintops of the Giants).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Erdtree Avatar (Mountaintops of the Giants).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318754</ID>
+  <Description>"Erdtree Avatar (Mountaintops of the Giants)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Fire Giant.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Fire Giant.cea
@@ -1,0 +1,29 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+1252520801,
+1252520804,
+1052522810,
+-- Defeat Flags
+1252520800,
+-- Reward Flags
+9131,
+510310,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "FireGiantThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "FireGiantThread")
+
+disableMemrec(memrec, function() return not ef.FireGiantThread end)
+
+[DISABLE]
+ef.FireGiantThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Fire Giant.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Fire Giant.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318690</ID>
+  <Description>"Fire Giant"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Roundtable Knight Vyke.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Roundtable Knight Vyke.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1053560800,
+
+-- Reward Flags
+
+530515,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "VykeThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "VykeThread")
+
+disableMemrec(memrec, function() return not ef.VykeThread end)
+
+[DISABLE]
+ef.VykeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Roundtable Knight Vyke.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Roundtable Knight Vyke.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318812</ID>
+  <Description>"Roundtable Knight Vyke"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Spirit-Caller Snail (Godskins).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Spirit-Caller Snail (Godskins).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31220800,
+
+-- Reward Flags
+9248,
+520480,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "GodskinSnailThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GodskinSnailThread")
+
+disableMemrec(memrec, function() return not ef.GodskinSnailThread end)
+
+[DISABLE]
+ef.GodskinSnailThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Spirit-Caller Snail (Godskins).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Spirit-Caller Snail (Godskins).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318820</ID>
+  <Description>"Spirit-Caller Snail (Godskins)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ulcerated Tree Spirit (Mountaintops of the Giants).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ulcerated Tree Spirit (Mountaintops of the Giants).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+30180801,
+
+-- Defeat Flags
+30180800,
+
+-- Reward Flags
+9218,
+520180,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "SpiritMotGThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "SpiritMotGThread")
+
+disableMemrec(memrec, function() return not ef.SpiritMotGThread end)
+
+[DISABLE]
+ef.SpiritMotGThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ulcerated Tree Spirit (Mountaintops of the Giants).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mountaintops of the Giants/Ulcerated Tree Spirit (Mountaintops of the Giants).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318829</ID>
+  <Description>"Ulcerated Tree Spirit (Mountaintops of the Giants)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/.xml
@@ -1,0 +1,21 @@
+<CheatEntry>
+  <ID>1337318840</ID>
+  <Description>"Mt. Gelmir"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318680"/>
+    <id id="1337318747"/>
+    <id id="1337318746"/>
+    <id id="1337318763"/>
+    <id id="1337318769"/>
+    <id id="1337318785"/>
+    <id id="1337318788"/>
+    <id id="1337318811"/>
+    <id id="1337318815"/>
+    <id id="1337318826"/>
+    <id id="1337318651"/>
+    <id id="1337318652"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Abductor Virgins.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Abductor Virgins.cea
@@ -1,0 +1,26 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+-- Defeat Flags
+16000860,
+-- Reward Flags
+9129,
+510290,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "AbductorsThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "AbductorsThread")
+
+disableMemrec(memrec, function() return not ef.AbductorsThread end)
+
+[DISABLE]
+ef.AbductorsThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Abductor Virgins.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Abductor Virgins.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318680</ID>
+  <Description>"Abductor Virgins"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Maggie.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Maggie.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1037530800,
+
+-- Reward Flags
+
+60450,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MaggieThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MaggieThread")
+
+disableMemrec(memrec, function() return not ef.MaggieThread end)
+
+[DISABLE]
+ef.MaggieThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Maggie.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Maggie.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318746</ID>
+  <Description>"Demi-Human Queen Maggie"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Margot.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Margot.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31090800,
+
+-- Reward Flags
+9240,
+520400,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MargotThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MargotThread")
+
+disableMemrec(memrec, function() return not ef.MargotThread end)
+
+[DISABLE]
+ef.MargotThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Margot.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Demi-Human Queen Margot.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318747</ID>
+  <Description>"Demi-Human Queen Margot"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Erdtree Burial Watchdog (Mt. Gelmir).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Erdtree Burial Watchdog (Mt. Gelmir).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30070800,
+
+-- Reward Flags
+9212,
+520120,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "WatchdogGelmirThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "WatchdogGelmirThread")
+
+disableMemrec(memrec, function() return not ef.WatchdogGelmirThread end)
+
+[DISABLE]
+ef.WatchdogGelmirThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Erdtree Burial Watchdog (Mt. Gelmir).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Erdtree Burial Watchdog (Mt. Gelmir).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318763</ID>
+  <Description>"Erdtree Burial Watchdog (Mt. Gelmir)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Full-Grown Fallingstar Beast.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Full-Grown Fallingstar Beast.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1036540800,
+
+-- Reward Flags
+530375,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "FGSBThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "FGSBThread")
+
+disableMemrec(memrec, function() return not ef.FGSBThread end)
+
+[DISABLE]
+ef.FGSBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Full-Grown Fallingstar Beast.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Full-Grown Fallingstar Beast.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318769</ID>
+  <Description>"Full-Grown Fallingstar Beast"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Godskin Noble.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Godskin Noble.cea
@@ -1,0 +1,27 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+16000851,
+
+-- Boss Death
+16000850,
+
+--Reward Stuff
+9121, -- Wait until Boss is dead
+510210, -- Stitchah
+
+-- Remove grace from the unlocked list
+71601,
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GodskinNobleThread")
+disableMemrec(memrec, function() return not ef.GodskinNobleThread end)
+
+[DISABLE]
+ef.GodskinNobleThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Godskin Noble.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Godskin Noble.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318651</ID>
+  <Description>"Godskin Noble"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Kindred of Rot Duo.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Kindred of Rot Duo.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+31070800,
+
+-- Reward Flags
+9239,
+
+-- Extra Flags
+520390,
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "KoRThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "KoRThread")
+
+disableMemrec(memrec, function() return not ef.KoRThread end)
+
+[DISABLE]
+ef.KoRThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Kindred of Rot Duo.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Kindred of Rot Duo.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318785</ID>
+  <Description>"Kindred of Rot Duo"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Magma Wyrm Mt. Gelmir.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Magma Wyrm Mt. Gelmir.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1035530800,
+
+-- Reward Flags
+9339,
+530390,
+-- Extra Flags
+
+76161,
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MagmuhGelThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MagmuhGelThread")
+
+disableMemrec(memrec, function() return not ef.MagmuhGelThread end)
+
+[DISABLE]
+ef.MagmuhGelThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Magma Wyrm Mt. Gelmir.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Magma Wyrm Mt. Gelmir.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318788</ID>
+  <Description>"Magma Wyrm Mt. Gelmir"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Red Wolf of the Champion.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Red Wolf of the Champion.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30090800,
+
+-- Reward Flags
+9209,
+520090,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "RedWolfofChampThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RedWolfofChampThread")
+
+disableMemrec(memrec, function() return not ef.RedWolfofChampThread end)
+
+[DISABLE]
+ef.RedWolfofChampThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Red Wolf of the Champion.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Red Wolf of the Champion.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318811</ID>
+  <Description>"Red Wolf of the Champion"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Rykard, Lord of Blasphemy.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Rykard, Lord of Blasphemy.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+16000801,
+
+-- Boss Death
+16000800,
+
+--Reward Stuff
+9122, -- Wait until Boss is dead
+510220, -- Remembrance
+
+-- Remove grace from the unlocked list
+71600,
+
+-- Remove Rykard's Corpse/Move Tanith back to manor
+3109,3110,3111,
+
+--
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RichardThread")
+disableMemrec(memrec, function() return not ef.RichardThread end)
+
+[DISABLE]
+ef.RichardThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Rykard, Lord of Blasphemy.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Rykard, Lord of Blasphemy.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318652</ID>
+  <Description>"Rykard, Lord of Blasphemy"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Sanguine Noble.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Sanguine Noble.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1040530800,
+
+-- Reward Flags
+
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "SanguineNobleThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "SanguineNobleThread")
+
+disableMemrec(memrec, function() return not ef.SanguineNobleThread end)
+
+[DISABLE]
+ef.SanguineNobleThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Sanguine Noble.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Sanguine Noble.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318815</ID>
+  <Description>"Sanguine Noble"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Ulcerated Tree Spirit (Mt. Gelmir).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Ulcerated Tree Spirit (Mt. Gelmir).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+1037540810,
+
+-- Reward Flags
+65180,
+65250,
+-- Extras
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "SpiritGelThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "SpiritGelThread")
+
+disableMemrec(memrec, function() return not ef.SpiritGelThread end)
+
+[DISABLE]
+ef.SpiritGelThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Ulcerated Tree Spirit (Mt. Gelmir).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Mt. Gelmir/Ulcerated Tree Spirit (Mt. Gelmir).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318826</ID>
+  <Description>"Ulcerated Tree Spirit (Mt. Gelmir)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318852</ID>
+  <Description>"Nokron, Eternal City"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318696"/>
+    <id id="1337318702"/>
+    <id id="1337318693"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Mimic Tear.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Mimic Tear.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+12020851,
+-- Defeat Flags
+12020850,
+-- Reward Flags
+9134,
+510340,
+-- Extra
+71500,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MimicThread")
+
+--local flagsToOne = {
+--4130,
+--}
+-- local flags2 = {flagsToOne}
+-- sleep(200)
+--ef.batchSetFlags(flags2, 1, "MimicThread")
+
+disableMemrec(memrec, function() return not ef.MimicThread end)
+
+[DISABLE]
+ef.MimicThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Mimic Tear.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Mimic Tear.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318696</ID>
+  <Description>"Mimic Tear"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Regal Ancestor Spirit.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Regal Ancestor Spirit.cea
@@ -1,0 +1,29 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+
+-- Defeat Flags
+12090800,
+-- Reward Flags
+9133,
+510330,
+-- Extra
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RegalThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "RegalThread")
+
+disableMemrec(memrec, function() return not ef.RegalThread end)
+
+[DISABLE]
+ef.RegalThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Regal Ancestor Spirit.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Regal Ancestor Spirit.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318702</ID>
+  <Description>"Regal Ancestor Spirit"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Valiant Gargoyles.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Valiant Gargoyles.cea
@@ -1,0 +1,31 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+12020801,
+
+-- Defeat Flags
+12020800,
+-- Reward Flags
+9110,
+510100,
+-- Extra
+71220,
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GargsThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "GargsThread")
+
+disableMemrec(memrec, function() return not ef.GargsThread end)
+
+[DISABLE]
+ef.GargsThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Valiant Gargoyles.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Nokron, Eternal City/Valiant Gargoyles.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318693</ID>
+  <Description>"Valiant Gargoyles"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318838</ID>
+  <Description>"Siofra River"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318681"/>
+    <id id="1337318750"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Ancestor Spirit.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Ancestor Spirit.cea
@@ -1,0 +1,29 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+-- Defeat Flags
+12080800,
+12082800,
+-- Reward Flags
+9132,
+510320,
+
+12085005,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "AncestorThread")
+
+--local flagsToOne = {}
+-- local flags2 = {flagsToOne}
+-- sleep(1200)
+-- ef.batchSetFlags(flags2, 1, "AncestorThread")
+
+disableMemrec(memrec, function() return not ef.AncestorThread end)
+
+[DISABLE]
+ef.AncestorThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Ancestor Spirit.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Ancestor Spirit.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318681</ID>
+  <Description>"Ancestor Spirit"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Dragonkin Soldier (Siofra River).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Dragonkin Soldier (Siofra River).cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+12020830,
+
+-- Reward Flags
+
+530620,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DragonSoldjahSiofraThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DragonSoldjahSiofraThread")
+
+disableMemrec(memrec, function() return not ef.DragonSoldjahSiofraThread end)
+
+[DISABLE]
+ef.DragonSoldjahSiofraThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Dragonkin Soldier (Siofra River).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Siofra River/Dragonkin Soldier (Siofra River).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318750</ID>
+  <Description>"Dragonkin Soldier (Siofra River)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Subterranean Shunning Grounds/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Subterranean Shunning Grounds/.xml
@@ -1,0 +1,10 @@
+<CheatEntry>
+  <ID>1337318664</ID>
+  <Description>"Subterranean Shunning Grounds"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318699"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Subterranean Shunning Grounds/Mohg the Omen.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Subterranean Shunning Grounds/Mohg the Omen.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+35000801,
+
+-- Defeat Flags
+35000800,
+
+-- Reward Flags
+9125,
+510250,
+
+-- Remove Grace from warp list
+73500,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "FakeAmohgusThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "FakeAmohgusThread")
+
+disableMemrec(memrec, function() return not ef.FakeAmohgusThread end)
+
+[DISABLE]
+ef.FakeAmohgusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Subterranean Shunning Grounds/Mohg the Omen.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Subterranean Shunning Grounds/Mohg the Omen.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318699</ID>
+  <Description>"Mohg the Omen"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/.xml
@@ -1,0 +1,19 @@
+<CheatEntry>
+  <ID>1337318839</ID>
+  <Description>"Weeping Peninsula"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318685"/>
+    <id id="1337318722"/>
+    <id id="1337318742"/>
+    <id id="1337318753"/>
+    <id id="1337318765"/>
+    <id id="1337318786"/>
+    <id id="1337318790"/>
+    <id id="1337318793"/>
+    <id id="1337318813"/>
+    <id id="1337318816"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Ancient Hero of Zamor (Weeping Evergaol).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Ancient Hero of Zamor (Weeping Evergaol).cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1042330800,
+
+-- Reward Flags
+1042337100,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AncientHeroWEThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "AncientHeroWEThread")
+
+disableMemrec(memrec, function() return not ef.AncientHeroWEThread end)
+
+[DISABLE]
+ef.AncientHeroWEThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Ancient Hero of Zamor (Weeping Evergaol).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Ancient Hero of Zamor (Weeping Evergaol).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318685</ID>
+  <Description>"Ancient Hero of Zamor (Weeping Evergaol)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Cemetery Shade (Weeping).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Cemetery Shade (Weeping).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30000800,
+
+-- Reward Flags
+9200,
+520000,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ShadeWPThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+
+--}
+
+--local flags2 = {flagsToOne}
+
+ --sleep(300)
+
+--ef.batchSetFlags(flags2, 1, "ShadeWPThread")
+
+disableMemrec(memrec, function() return not ef.ShadeWPThread end)
+
+[DISABLE]
+ef.ShadeWPThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Cemetery Shade (Weeping).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Cemetery Shade (Weeping).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318722</ID>
+  <Description>"Cemetery Shade (Weeping)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Deathbird (Weeping Peninsula).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Deathbird (Weeping Peninsula).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1044320800,
+
+-- Reward Flags
+1044327400,
+-- Extra Flags
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "DBWPThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DBWPThread")
+
+disableMemrec(memrec, function() return not ef.DBWPThread end)
+
+[DISABLE]
+ef.DBWPThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Deathbird (Weeping Peninsula).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Deathbird (Weeping Peninsula).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318742</ID>
+  <Description>"Deathbird (Weeping Peninsula)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Avatar (Weeping Peninsula).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Avatar (Weeping Peninsula).cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1043330800,
+
+-- Reward Flags
+65090,
+65080,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "AvatarWeepingThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AvatarWeepingThread")
+
+disableMemrec(memrec, function() return not ef.AvatarWeepingThread end)
+
+[DISABLE]
+ef.AvatarWeepingThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Avatar (Weeping Peninsula).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Avatar (Weeping Peninsula).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318753</ID>
+  <Description>"Erdtree Avatar (Weeping Peninsula)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Burial Watchdog (Weeping Peninsula).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Burial Watchdog (Weeping Peninsula).cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+30010800,
+
+-- Reward Flags
+9201,
+520010,
+-- Extra Flags
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "WatchdogWPThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "WatchdogWPThread")
+
+disableMemrec(memrec, function() return not ef.WatchdogWPThread end)
+
+[DISABLE]
+ef.WatchdogWPThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Burial Watchdog (Weeping Peninsula).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Erdtree Burial Watchdog (Weeping Peninsula).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318765</ID>
+  <Description>"Erdtree Burial Watchdog (Weeping Peninsula)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Leonine Misbegotten.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Leonine Misbegotten.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+-- Defeat Flags
+1043300800,
+
+-- Reward Flags
+9180,
+510800,
+-- Extra Flags
+
+76161,
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "LeonineThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "LeonineThread")
+
+disableMemrec(memrec, function() return not ef.LeonineThread end)
+
+[DISABLE]
+ef.LeonineThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Leonine Misbegotten.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Leonine Misbegotten.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318786</ID>
+  <Description>"Leonine Misbegotten"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Miranda Blossom.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Miranda Blossom.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+
+-- Defeat Flags
+31020800,
+
+-- Reward Flags
+9230,
+520300,
+-- Extra Flags
+
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "MirandaThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MirandaThread")
+
+disableMemrec(memrec, function() return not ef.MirandaThread end)
+
+[DISABLE]
+ef.MirandaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Miranda Blossom.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Miranda Blossom.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318790</ID>
+  <Description>"Miranda Blossom"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Night's Cavalry (Weeping Peninsula).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Night's Cavalry (Weeping Peninsula).cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+
+
+-- Defeat Flags
+1044320850,
+
+-- Reward Flags
+1044327410,
+-- Extra Flags
+
+
+
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "NCWPThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "NCWPThread")
+
+disableMemrec(memrec, function() return not ef.NCWPThread end)
+
+[DISABLE]
+ef.NCWPThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Night's Cavalry (Weeping Peninsula).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Night's Cavalry (Weeping Peninsula).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318793</ID>
+  <Description>"Night's Cavalry (Weeping Peninsula)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Runebear.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Runebear.cea
@@ -1,0 +1,32 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+31010801,
+-- Defeat Flags
+31010800,
+
+-- Reward Flags
+9231,
+520310,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "RunebearThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RunebearThread")
+
+disableMemrec(memrec, function() return not ef.RunebearThread end)
+
+[DISABLE]
+ef.RunebearThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Runebear.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Runebear.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318813</ID>
+  <Description>"Runebear"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Scaly Misbegotten.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Scaly Misbegotten.cea
@@ -1,0 +1,33 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter Flags
+32000590,
+32000801,
+-- Defeat Flags
+32000800,
+
+-- Reward Flags
+9260,
+520600,
+-- Extra Flags
+
+}
+
+local flags = {flagsBase}
+ef.batchSetFlags(flags, 0, "ScalyThread")
+
+-- Extra section if I need flags set to 1
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ScalyThread")
+
+disableMemrec(memrec, function() return not ef.ScalyThread end)
+
+[DISABLE]
+ef.ScalyThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Scaly Misbegotten.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Base Game/Weeping Peninsula/Scaly Misbegotten.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318816</ID>
+  <Description>"Scaly Misbegotten"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/How to use.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/How to use.cea
@@ -1,0 +1,28 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+disableMemrec(memrec)
+showText("Boss Revival Important Readme", [[
+I'm stupid so I don't know how to make this work perfectly, read so you don't complain to me later. I'm trying my best here...
+
+To revive a boss just toggle the script and reload the area.
+
+Important info:
+Some bosses have the param 'disableInitializeDead' turned off, what this does is essentially decide whether a boss will be revived (or "regenerated") on a quitout or not.
+That means bosses like Godrick and Mohg will instantly die if you revive and quitout to reload the area.
+However if you teleport to a nearby grace the boss will function just fine and will remain functional even if you quitout afterwards.
+Why? I don't know.
+
+For best results enable the "Warp out of uncleared mini-dungeons" script which can be found in Scripts >> QoL and warp back to the nearest grace when reviving a boss. Or revive before warping to the boss.
+Even if you're next to a grace preferably warp out instead of resting because some events require a full area reload to actually initalize (idk the details).
+
+You can visit this google sheet to confirm if a boss needs a full reload with a warp or if a quitout is enough https://docs.google.com/spreadsheets/d/1C6Q_z3Ko8oXhfVji8U4VMSR4BxnCCi5-spGKMKeQVKo/
+
+Rennala is slightly buggy to revive, after you quitout the scholars will spawn before you even trigger the fight, but only up to 6 and that sometimes affects performance, I don't know why that happens or how to prevent it without closing the door of the boss room, I've tried many things trust me.
+Anyway... one or two scholars will always spawn at the very back (directly in front of you when you open the door) but that's a vanilla interaction so don't worry about it, if they are spawning from other locations then please reload the area again.
+
+Documented by Recycle
+]])
+
+[DISABLE]

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/How to use.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/How to use.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318641</ID>
+  <Description>"How to use"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/.xml
@@ -1,0 +1,18 @@
+<CheatEntry>
+  <ID>1337318861</ID>
+  <Description>"Shadow of the Erdtree"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318869"/>
+    <id id="1337318922"/>
+    <id id="1337318938"/>
+    <id id="1337318943"/>
+    <id id="1337318947"/>
+    <id id="1337318950"/>
+    <id id="1337318955"/>
+    <id id="1337318958"/>
+    <id id="1337318963"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318955</ID>
+  <Description>"Abyssal Wood"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318956"/>
+    <id id="1337318957"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Jori, Elder Inquisitor.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Jori, Elder Inquisitor.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2052430800,
+
+-- Reward Flags
+9161,
+510610,
+
+-- Remove Grace from warp list
+76862,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "AssholeThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "AssholeThread")
+
+disableMemrec(memrec, function() return not ef.AssholeThread end)
+
+[DISABLE]
+ef.AssholeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Jori, Elder Inquisitor.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Jori, Elder Inquisitor.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318956</ID>
+  <Description>"Jori, Elder Inquisitor"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Midra, Lord of Frenzied Flame.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Midra, Lord of Frenzied Flame.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+28000801,
+-- Defeat Flags
+28000800,
+
+-- Reward Flags
+9156,
+510560,
+
+-- Remove Grace from warp list
+72800,
+
+-- Extra
+28009212, -- mini midra screaming because funneh xdd
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MidThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MidThread")
+
+disableMemrec(memrec, function() return not ef.MidThread end)
+
+[DISABLE]
+ef.MidThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Midra, Lord of Frenzied Flame.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Abyssal Wood/Midra, Lord of Frenzied Flame.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318957</ID>
+  <Description>"Midra, Lord of Frenzied Flame"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/.xml
@@ -1,0 +1,12 @@
+<CheatEntry>
+  <ID>1337318943</ID>
+  <Description>"Cerulean Coast"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318944"/>
+    <id id="1337318945"/>
+    <id id="1337318946"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Dancer of Ranah.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Dancer of Ranah.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2046380800,
+
+-- Reward Flags
+530810,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "DancerThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DancerThread")
+
+disableMemrec(memrec, function() return not ef.DancerThread end)
+
+[DISABLE]
+ef.DancerThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Dancer of Ranah.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Dancer of Ranah.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318944</ID>
+  <Description>"Dancer of Ranah"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Ghostflame Dragon.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Ghostflame Dragon.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+2048380870,
+-- Defeat Flags
+2048380850,
+
+-- Reward Flags
+530840,
+
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "CCGhostflameThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "CCGhostflameThread")
+
+disableMemrec(memrec, function() return not ef.CCGhostflameThread end)
+
+[DISABLE]
+ef.CCGhostflameThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Ghostflame Dragon.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Ghostflame Dragon.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318945</ID>
+  <Description>"Ghostflame Dragon"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Putrescent Knight.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Putrescent Knight.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+22000802,
+-- Defeat Flags
+22000800,
+
+-- Reward Flags
+9148,
+510480,
+
+-- Remove Grace from warp list
+72200,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "PKThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "PKThread")
+
+disableMemrec(memrec, function() return not ef.PKThread end)
+
+[DISABLE]
+ef.PKThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Putrescent Knight.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Cerulean Coast/Putrescent Knight.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318946</ID>
+  <Description>"Putrescent Knight"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318947</ID>
+  <Description>"Charo's Hidden Grave"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318948"/>
+    <id id="1337318949"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Death Rite Bird.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Death Rite Bird.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2047390800,
+
+-- Reward Flags
+530855,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "DlcDRBThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DlcDRBThread")
+
+disableMemrec(memrec, function() return not ef.DlcDRBThread end)
+
+[DISABLE]
+ef.DlcDRBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Death Rite Bird.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Death Rite Bird.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318948</ID>
+  <Description>"Death Rite Bird"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Demi-Human Queen Marigga.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Demi-Human Queen Marigga.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2046400800,
+
+-- Reward Flags
+530845,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MariggaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MariggaThread")
+
+disableMemrec(memrec, function() return not ef.MariggaThread end)
+
+[DISABLE]
+ef.MariggaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Demi-Human Queen Marigga.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Charo's Hidden Grave/Demi-Human Queen Marigga.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318949</ID>
+  <Description>"Demi-Human Queen Marigga"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318963</ID>
+  <Description>"Enir Ilim"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318964"/>
+    <id id="1337318965"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Leda & Allies.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Leda & Allies.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2046450800,
+
+-- Reward Flags
+
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "LedaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "LedaThread")
+
+disableMemrec(memrec, function() return not ef.LedaThread end)
+
+[DISABLE]
+ef.LedaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Leda & Allies.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Leda & Allies.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318964</ID>
+  <Description>"Leda &amp; Allies"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Promised Consort Radahn.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Promised Consort Radahn.cea
@@ -1,0 +1,42 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+20010801,
+-- Defeat Flags
+20010800,
+
+-- Reward Flags
+9143,
+510430,
+
+-- Remove Grace from warp list
+72010,
+
+-- Extra
+20010199,
+20012199,
+20017981,
+128,
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "CUUUUUUNTThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "CUUUUUUNTThread")
+
+disableMemrec(memrec, function() return not ef.CUUUUUUNTThread end)
+
+[DISABLE]
+ef.CUUUUUUNTThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Promised Consort Radahn.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Enir Ilim/Promised Consort Radahn.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318965</ID>
+  <Description>"Promised Consort Radahn"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/.xml
@@ -1,0 +1,17 @@
+<CheatEntry>
+  <ID>1337318869</ID>
+  <Description>"Gravesite Plain"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318860"/>
+    <id id="1337318862"/>
+    <id id="1337318863"/>
+    <id id="1337318864"/>
+    <id id="1337318865"/>
+    <id id="1337318866"/>
+    <id id="1337318867"/>
+    <id id="1337318868"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Blackgaol Knight.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Blackgaol Knight.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2046410800,
+
+-- Reward Flags
+
+530820,
+
+-- Remove Grace from warp list
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GaolKnightThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GaolKnightThread")
+
+disableMemrec(memrec, function() return not ef.GaolKnightThread end)
+
+[DISABLE]
+ef.GaolKnightThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Blackgaol Knight.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Blackgaol Knight.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318860</ID>
+  <Description>"Blackgaol Knight"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Chief Bloodfiend.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Chief Bloodfiend.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+43000800,
+
+-- Reward Flags
+9280,
+520800,
+
+-- Remove Grace from warp list
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "BloodfiendThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "BloodfiendThread")
+
+disableMemrec(memrec, function() return not ef.BloodfiendThread end)
+
+[DISABLE]
+ef.BloodfiendThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Chief Bloodfiend.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Chief Bloodfiend.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318862</ID>
+  <Description>"Chief Bloodfiend"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Demi-Human Swordmaster Onze.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Demi-Human Swordmaster Onze.cea
@@ -1,0 +1,34 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+41000800,
+
+-- Reward Flags
+9275,
+520750,
+
+-- Remove Grace from warp list
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "OnzeThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "OnzeThread")
+
+disableMemrec(memrec, function() return not ef.OnzeThread end)
+
+[DISABLE]
+ef.OnzeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Demi-Human Swordmaster Onze.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Demi-Human Swordmaster Onze.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318863</ID>
+  <Description>"Demi-Human Swordmaster Onze"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Divine Beast Dancing Lion.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Divine Beast Dancing Lion.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+20000544,
+20000801,
+-- Defeat Flags
+20000800,
+
+-- Reward Flags
+9140,
+510400,
+
+-- Remove Grace from warp list
+72000,
+
+-- Extra
+20007810,
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "TheGoodLionThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "TheGoodLionThread")
+
+disableMemrec(memrec, function() return not ef.TheGoodLionThread end)
+
+[DISABLE]
+ef.TheGoodLionThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Divine Beast Dancing Lion.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Divine Beast Dancing Lion.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318864</ID>
+  <Description>"Divine Beast Dancing Lion"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Ghostflame Dragon.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Ghostflame Dragon.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+2045440820,
+-- Defeat Flags
+2045440800,
+
+-- Reward Flags
+530860,
+530861,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GhostflameGPThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GhostflameGPThread")
+
+disableMemrec(memrec, function() return not ef.GhostflameGPThread end)
+
+[DISABLE]
+ef.GhostflameGPThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Ghostflame Dragon.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Ghostflame Dragon.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318865</ID>
+  <Description>"Ghostflame Dragon"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Lamenter.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Lamenter.cea
@@ -1,0 +1,35 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+41020800,
+
+-- Reward Flags
+9277,
+520770,
+-- Remove Grace from warp list
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "LamenterThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "LamenterThread")
+
+disableMemrec(memrec, function() return not ef.LamenterThread end)
+
+[DISABLE]
+ef.LamenterThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Lamenter.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Lamenter.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318866</ID>
+  <Description>"Lamenter"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Red Bear.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Red Bear.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2046450800,
+
+-- Reward Flags
+530900,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RedBearThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RedBearThread")
+
+disableMemrec(memrec, function() return not ef.RedBearThread end)
+
+[DISABLE]
+ef.RedBearThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Red Bear.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Red Bear.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318868</ID>
+  <Description>"Red Bear"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Rellana, Twin Moon Knight.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Rellana, Twin Moon Knight.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2048440800,
+
+-- Reward Flags
+9190,
+510900,
+
+-- Remove Grace from warp list
+76823,
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RellanaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RellanaThread")
+
+disableMemrec(memrec, function() return not ef.RellanaThread end)
+
+[DISABLE]
+ef.RellanaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Rellana, Twin Moon Knight.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Gravesite Plain/Rellana, Twin Moon Knight.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318867</ID>
+  <Description>"Rellana, Twin Moon Knight"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/.xml
@@ -1,0 +1,14 @@
+<CheatEntry>
+  <ID>1337318950</ID>
+  <Description>"Jagged Peak"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318951"/>
+    <id id="1337318952"/>
+    <id id="1337318953"/>
+    <id id="1337318962"/>
+    <id id="1337318954"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon Senessax.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon Senessax.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2054390850,
+
+-- Reward Flags
+530805,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "SenessaxThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "SenessaxThread")
+
+disableMemrec(memrec, function() return not ef.SenessaxThread end)
+
+[DISABLE]
+ef.SenessaxThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon Senessax.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon Senessax.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318952</ID>
+  <Description>"Ancient Dragon Senessax"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon-Man.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon-Man.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+43010800,
+
+-- Reward Flags
+9281,
+520810,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+43018540, -- door
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MANThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MANThread")
+
+disableMemrec(memrec, function() return not ef.MANThread end)
+
+[DISABLE]
+ef.MANThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon-Man.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Ancient Dragon-Man.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318951</ID>
+  <Description>"Ancient Dragon-Man"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Bayle the Dragon.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Bayle the Dragon.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+2054390801,
+-- Defeat Flags
+2054390800,
+
+-- Reward Flags
+9163,
+510630,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "BayleThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "BayleThread")
+
+disableMemrec(memrec, function() return not ef.BayleThread end)
+
+[DISABLE]
+ef.BayleThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Bayle the Dragon.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Bayle the Dragon.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318953</ID>
+  <Description>"Bayle the Dragon"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake (Duo Encounter).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake (Duo Encounter).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2052400800,
+530800,
+
+-- Reward Flags
+
+
+-- Remove Grace from warp list
+
+
+-- Extra
+4267, -- get rid of the piece of shit called igon
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "WhatsbetterthanonedragonThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "WhatsbetterthanonedragonThread")
+
+disableMemrec(memrec, function() return not ef.WhatsbetterthanonedragonThread end)
+
+[DISABLE]
+ef.WhatsbetterthanonedragonThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake (Duo Encounter).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake (Duo Encounter).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318954</ID>
+  <Description>"Jagged Peak Drake (Duo Encounter)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2049410800,
+
+-- Reward Flags
+530850,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "DragonAfterMANThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DragonAfterMANThread")
+
+disableMemrec(memrec, function() return not ef.DragonAfterMANThread end)
+
+[DISABLE]
+ef.DragonAfterMANThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Jagged Peak/Jagged Peak Drake.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318962</ID>
+  <Description>"Jagged Peak Drake"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/.xml
@@ -1,0 +1,13 @@
+<CheatEntry>
+  <ID>1337318938</ID>
+  <Description>"Rauh Base"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318928"/>
+    <id id="1337318940"/>
+    <id id="1337318941"/>
+    <id id="1337318942"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Death Knight (Longhaft Axe).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Death Knight (Longhaft Axe).cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+40010800,
+
+-- Reward Flags
+9271,
+520710,
+520711,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "LonghaftDKThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "LonghaftDKThread")
+
+disableMemrec(memrec, function() return not ef.LonghaftDKThread end)
+
+[DISABLE]
+ef.LonghaftDKThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Death Knight (Longhaft Axe).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Death Knight (Longhaft Axe).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318928</ID>
+  <Description>"Death Knight (Longhaft Axe)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Divine Beast Dancing Lion.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Divine Beast Dancing Lion.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2046460800,
+
+-- Reward Flags
+530940,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "TheBadLionThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "TheBadLionThread")
+
+disableMemrec(memrec, function() return not ef.TheBadLionThread end)
+
+[DISABLE]
+ef.TheBadLionThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Divine Beast Dancing Lion.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Divine Beast Dancing Lion.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318940</ID>
+  <Description>"Divine Beast Dancing Lion"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Romina Saint of the Bud.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Romina Saint of the Bud.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2044450800,
+
+-- Reward Flags
+9160,
+510600,
+
+-- Remove Grace from warp list
+76945,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RomaniaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RomaniaThread")
+
+disableMemrec(memrec, function() return not ef.RomaniaThread end)
+
+[DISABLE]
+ef.RomaniaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Romina Saint of the Bud.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Romina Saint of the Bud.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318941</ID>
+  <Description>"Romina Saint of the Bud"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Rugalea the Great Red Bear.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Rugalea the Great Red Bear.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2044470800,
+
+-- Reward Flags
+2044477010,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RugaleaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RugaleaThread")
+
+disableMemrec(memrec, function() return not ef.RugaleaThread end)
+
+[DISABLE]
+ef.RugaleaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Rugalea the Great Red Bear.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Rauh Base/Rugalea the Great Red Bear.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318942</ID>
+  <Description>"Rugalea the Great Red Bear"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/.xml
@@ -1,0 +1,24 @@
+<CheatEntry>
+  <ID>1337318922</ID>
+  <Description>"Scadu Altus"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318923"/>
+    <id id="1337318924"/>
+    <id id="1337318925"/>
+    <id id="1337318926"/>
+    <id id="1337318927"/>
+    <id id="1337318939"/>
+    <id id="1337318929"/>
+    <id id="1337318930"/>
+    <id id="1337318931"/>
+    <id id="1337318932"/>
+    <id id="1337318933"/>
+    <id id="1337318934"/>
+    <id id="1337318935"/>
+    <id id="1337318936"/>
+    <id id="1337318937"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Edredd.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Edredd.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2049430850,
+
+-- Reward Flags
+530965,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "EdreddThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "EdreddThread")
+
+disableMemrec(memrec, function() return not ef.EdreddThread end)
+
+[DISABLE]
+ef.EdreddThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Edredd.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Edredd.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318923</ID>
+  <Description>"Black Knight Edredd"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Garrew.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Garrew.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2047450800,
+
+-- Reward Flags
+530955,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GarrewThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GarrewThread")
+
+disableMemrec(memrec, function() return not ef.GarrewThread end)
+
+[DISABLE]
+ef.GarrewThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Garrew.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Black Knight Garrew.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318924</ID>
+  <Description>"Black Knight Garrew"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Commander Gaius.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Commander Gaius.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+2049480801,
+-- Defeat Flags
+2049480800,
+
+-- Reward Flags
+9164,
+510640,
+
+-- Remove Grace from warp list
+76930,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "GaiusThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "GaiusThread")
+
+disableMemrec(memrec, function() return not ef.GaiusThread end)
+
+[DISABLE]
+ef.GaiusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Commander Gaius.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Commander Gaius.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318925</ID>
+  <Description>"Commander Gaius"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Count Ymir Mother of Fingers.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Count Ymir Mother of Fingers.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2051450800,
+
+-- Reward Flags
+400664
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "YmirThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "YmirThread")
+
+disableMemrec(memrec, function() return not ef.YmirThread end)
+
+[DISABLE]
+ef.YmirThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Count Ymir Mother of Fingers.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Count Ymir Mother of Fingers.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318926</ID>
+  <Description>"Count Ymir Mother of Fingers"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Curseblade Labirith.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Curseblade Labirith.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+41010800,
+
+-- Reward Flags
+9276,
+520760,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "CursebladeThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "CursebladeThread")
+
+disableMemrec(memrec, function() return not ef.CursebladeThread end)
+
+[DISABLE]
+ef.CursebladeThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Curseblade Labirith.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Curseblade Labirith.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318927</ID>
+  <Description>"Curseblade Labirith"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Death Knight (Twin Axes).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Death Knight (Twin Axes).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+40000800,
+
+-- Reward Flags
+9270,
+520700,
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "TAKnightThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "TAKnightThread")
+
+disableMemrec(memrec, function() return not ef.TAKnightThread end)
+
+[DISABLE]
+ef.TAKnightThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Death Knight (Twin Axes).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Death Knight (Twin Axes).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318939</ID>
+  <Description>"Death Knight (Twin Axes)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Dryleaf Dane.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Dryleaf Dane.cea
@@ -1,0 +1,37 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2049440800,
+
+-- Reward Flags
+400730,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+2049442703,
+4909,
+2049449211,
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "DaneThread")
+
+--local flagsToOne = {
+--}
+--local flags2 = {flagsToOne}
+--sleep(600)
+--ef.batchSetFlags(flags2, 1, "DaneThread")
+
+disableMemrec(memrec, function() return not ef.DaneThread end)
+
+[DISABLE]
+ef.DaneThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Dryleaf Dane.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Dryleaf Dane.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318929</ID>
+  <Description>"Dryleaf Dane"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ghostflame Dragon.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ghostflame Dragon.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2049430800,
+
+-- Reward Flags
+530945,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "SAGhostflameThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "SAGhostflameThread")
+
+disableMemrec(memrec, function() return not ef.SAGhostflameThread end)
+
+[DISABLE]
+ef.SAGhostflameThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ghostflame Dragon.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ghostflame Dragon.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318930</ID>
+  <Description>"Ghostflame Dragon"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Golden Hippopotamus.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Golden Hippopotamus.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+21000851,
+-- Defeat Flags
+21000850,
+
+-- Reward Flags
+9144,
+510440,
+-- Remove Grace from warp list
+72101,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "HippopotamusThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "HippopotamusThread")
+
+disableMemrec(memrec, function() return not ef.HippopotamusThread end)
+
+[DISABLE]
+ef.HippopotamusThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Golden Hippopotamus.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Golden Hippopotamus.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318931</ID>
+  <Description>"Golden Hippopotamus"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Messmer The Impaler.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Messmer The Impaler.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+21018542,
+21010801,
+-- Defeat Flags
+21010800,
+
+-- Reward Flags
+9146,
+510460,
+
+-- Remove Grace from warp list
+72110,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MessmerThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MessmerThread")
+
+disableMemrec(memrec, function() return not ef.MessmerThread end)
+
+[DISABLE]
+ef.MessmerThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Messmer The Impaler.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Messmer The Impaler.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318932</ID>
+  <Description>"Messmer The Impaler"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Metyr Mother of Fingers.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Metyr Mother of Fingers.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+25000800,
+
+-- Reward Flags
+9155,
+510550,
+
+
+-- Remove Grace from warp list
+72500,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "MetyrThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MetyrThread")
+
+disableMemrec(memrec, function() return not ef.MetyrThread end)
+
+[DISABLE]
+ef.MetyrThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Metyr Mother of Fingers.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Metyr Mother of Fingers.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318933</ID>
+  <Description>"Metyr Mother of Fingers"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Rakshasa.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Rakshasa.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2051440800,
+
+-- Reward Flags
+530830,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RakshasaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RakshasaThread")
+
+disableMemrec(memrec, function() return not ef.RakshasaThread end)
+
+[DISABLE]
+ef.RakshasaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Rakshasa.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Rakshasa.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318934</ID>
+  <Description>"Rakshasa"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ralva the Great Red Bear.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ralva the Great Red Bear.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2049450800,
+
+-- Reward Flags
+530930,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "RalvaThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "RalvaThread")
+
+disableMemrec(memrec, function() return not ef.RalvaThread end)
+
+[DISABLE]
+ef.RalvaThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ralva the Great Red Bear.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Ralva the Great Red Bear.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318935</ID>
+  <Description>"Ralva the Great Red Bear"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Shield).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Shield).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2050480860,
+
+-- Reward Flags
+530950,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "ShieldTSThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ShieldTSThread")
+
+disableMemrec(memrec, function() return not ef.ShieldTSThread end)
+
+[DISABLE]
+ef.ShieldTSThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Shield).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Shield).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318936</ID>
+  <Description>"Tree Sentinel (Shield)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Torch).cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Torch).cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2050470800,
+
+-- Reward Flags
+530935,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "TorchTSThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "TorchTSThread")
+
+disableMemrec(memrec, function() return not ef.TorchTSThread end)
+
+[DISABLE]
+ef.TorchTSThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Torch).xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scadu Altus/Tree Sentinel (Torch).xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318937</ID>
+  <Description>"Tree Sentinel (Torch)"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/.xml
@@ -1,0 +1,11 @@
+<CheatEntry>
+  <ID>1337318958</ID>
+  <Description>"Scaduview"</Description>
+  <Options moHideChildren="1"/>
+  <LastState Value="" RealAddress="00000000"/>
+  <GroupHeader>1</GroupHeader>
+  <x-ce2fs-child-order>
+    <id id="1337318959"/>
+    <id id="1337318960"/>
+  </x-ce2fs-child-order>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Fallingstar Beast.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Fallingstar Beast.cea
@@ -1,0 +1,36 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+
+-- Defeat Flags
+2052480800,
+
+-- Reward Flags
+530960,
+
+-- Remove Grace from warp list
+
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "DlcFSBThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "DlcFSBThread")
+
+disableMemrec(memrec, function() return not ef.DlcFSBThread end)
+
+[DISABLE]
+ef.DlcFSBThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Fallingstar Beast.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Fallingstar Beast.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318959</ID>
+  <Description>"Fallingstar Beast"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Scadutree Avatar.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Scadutree Avatar.cea
@@ -1,0 +1,38 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+-- First Encounter
+2050480801,
+
+-- Defeat Flags
+2050480800,
+
+-- Reward Flags
+9162,
+510620,
+
+-- Remove Grace from warp list
+76960,
+
+-- Extra
+
+
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 0, "ScadAvThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "ScadAvThread")
+
+disableMemrec(memrec, function() return not ef.ScadAvThread end)
+
+[DISABLE]
+ef.ScadAvThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Scadutree Avatar.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Boss Revive/Shadow of the Erdtree/Scaduview/Scadutree Avatar.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318960</ID>
+  <Description>"Scadutree Avatar"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Skip Metyr's Quest.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Skip Metyr's Quest.cea
@@ -1,0 +1,51 @@
+{$lua}
+if syntaxcheck then return end
+
+[ENABLE]
+local flagsBase = {
+
+-- Move Ymir?
+2050400600,
+2053460600,
+2051459226,
+2051459228,
+2051459229,
+2051459230,
+2051455023,
+2051459249,
+2051452717,
+2050407000,
+400662,
+4856,
+4855,
+4854,
+4849,
+2051452718,
+
+
+-- Move Chair?
+2051459213,
+2051450715,
+
+-- Activate Horn
+9440,
+
+-- Kill Invader & Award Player
+2051450180,
+}
+
+local flags = {flagsBase}
+
+ef.batchSetFlags(flags, 1, "MetyrQuestThread")
+
+--local flagsToOne = {
+
+--}
+--local flags2 = {flagsToOne}
+--sleep(200)
+--ef.batchSetFlags(flags2, 1, "MetyrQuestThread")
+
+disableMemrec(memrec, function() return not ef.MetyrQuestThread end)
+
+[DISABLE]
+ef.MetyrQuestThread = false

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Skip Metyr's Quest.xml
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Event Flags/Skip Metyr's Quest.xml
@@ -1,0 +1,7 @@
+<CheatEntry>
+  <ID>1337318966</ID>
+  <Description>"Skip Metyr's Quest"</Description>
+  <LastState/>
+  <Color>FF8000</Color>
+  <VariableType>Auto Assembler Script</VariableType>
+</CheatEntry>


### PR DESCRIPTION
have been working on this for a while and the table scripts were a blessing for testing purposes so I wanted to contribute what I've collected, 

Boss Revives will revive automatically to first encounter, the only known buggy boss is Dryleaf Dane if you kill him in the Leda Encounter but surely nobody will miss him

Documentation of the flags: sorry if the way I wrote the scripts was messy and sorry I didn't know how to make a revive all or how to split them to first encounter and non first, I'm sure they can be polished by someone smarter 🥹

https://docs.google.com/spreadsheets/d/1C6Q_z3Ko8oXhfVji8U4VMSR4BxnCCi5-spGKMKeQVKo