### PR TITLE
Fix "Reload Character" always loading slot 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
  - "Remove Seamless Co-op items" script
  - by [Axd1x8a](https://github.com/FeeeeK)
    - Kill all mobs not working in some cases
- - by [Umgak](https://github.com/Umgak)
+ - by [Umgak](https://github.com/Umgak):
    - Fix "Reload Character" always loading slot 0.
 
 ## [v1.17.0] - 2025-08-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
  - "Remove Seamless Co-op items" script
  - by [Axd1x8a](https://github.com/FeeeeK)
    - Kill all mobs not working in some cases
+ - by [Umgak](https://github.com/Umgak)
+   - Fix "Reload Character" always loading slot 0.
 
 ## [v1.17.0] - 2025-08-04
 ### Added

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Statistics/SaveLoad2/Reload Character.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Statistics/SaveLoad2/Reload Character.cea
@@ -1,6 +1,6 @@
 {$lua}
 if syntaxcheck then return end
 [ENABLE]
-writeInteger("[GameMan]+B78",readInteger("[GameMan]+AC0"))
+writeInteger("[GameMan]+B78", readInteger("[GameMan]+AC0"))
 disableMemrec(memrec)
 [DISABLE]

--- a/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Statistics/SaveLoad2/Reload Character.cea
+++ b/CheatTable/CheatEntries/Open - The Grand Archives - Elden Ring/Statistics/SaveLoad2/Reload Character.cea
@@ -1,6 +1,6 @@
 {$lua}
 if syntaxcheck then return end
 [ENABLE]
-writeInteger("[GameMan]+B78","[GameMan]+AC0")
+writeInteger("[GameMan]+B78",readInteger("[GameMan]+AC0"))
 disableMemrec(memrec)
 [DISABLE]


### PR DESCRIPTION
`writeInteger(CEAddressString, CEAddressString)` is invalid and always evaluates to `nil`, so it becomes `writeInteger(CEAddressString, nil)` 
Have to `readInteger` to get the actual value, then `writeInteger` to save it